### PR TITLE
Strengthen AgentBrowser navigation and form E2E

### DIFF
--- a/cpp/packages/infrastructure/agentbrowser/src/agentbrowser.cpp
+++ b/cpp/packages/infrastructure/agentbrowser/src/agentbrowser.cpp
@@ -23,6 +23,7 @@
 #include <regex>
 #include <sstream>
 #include <stdexcept>
+#include <map>
 #include <string>
 #include <thread>
 #include <unordered_set>
@@ -63,6 +64,110 @@ static size_t writeCallback(char* ptr, size_t size, size_t nmemb, void* userdata
     auto* target = static_cast<std::string*>(userdata);
     target->append(ptr, size * nmemb);
     return size * nmemb;
+}
+
+static bool startsWith(const std::string& value, const std::string& prefix) {
+    return value.rfind(prefix, 0) == 0;
+}
+
+static std::string urlEncode(const std::string& value) {
+    std::ostringstream encoded;
+    encoded << std::uppercase << std::hex;
+    for (unsigned char c : value) {
+        if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+            encoded << static_cast<char>(c);
+        } else if (c == ' ') {
+            encoded << '+';
+        } else {
+            encoded << '%' << std::setw(2) << std::setfill('0') << static_cast<int>(c) << std::setfill(' ');
+        }
+    }
+    return encoded.str();
+}
+
+static std::string removeFragment(const std::string& url) {
+    auto pos = url.find('#');
+    return pos == std::string::npos ? url : url.substr(0, pos);
+}
+
+static std::string resolveUrl(const std::string& baseUrl, const std::string& target) {
+    const std::string href = trim(target);
+    if (href.empty()) return baseUrl;
+    if (startsWith(href, "http://") || startsWith(href, "https://")) return href;
+
+    static const std::regex baseRegex(R"(^(https?)://([^/?#]+)([^?#]*)?(\?[^#]*)?(#.*)?$)", std::regex_constants::icase);
+    std::smatch match;
+    if (!std::regex_match(baseUrl, match, baseRegex)) return href;
+
+    const std::string scheme = match[1].str();
+    const std::string authority = match[2].str();
+    const std::string rawPath = match[3].matched && !match[3].str().empty() ? match[3].str() : "/";
+    const std::string origin = scheme + "://" + authority;
+
+    if (startsWith(href, "//")) return scheme + ":" + href;
+    if (href.front() == '/') return origin + href;
+    if (href.front() == '?') return origin + rawPath + href;
+    if (href.front() == '#') return removeFragment(baseUrl) + href;
+
+    std::string directory = rawPath;
+    auto slash = directory.rfind('/');
+    directory = (slash == std::string::npos) ? "/" : directory.substr(0, slash + 1);
+
+    std::vector<std::string> segments;
+    auto pushSegments = [&](const std::string& path) {
+        std::size_t start = 0;
+        while (start <= path.size()) {
+            const auto end = path.find('/', start);
+            std::string part = path.substr(start, end == std::string::npos ? std::string::npos : end - start);
+            if (!part.empty() && part != ".") {
+                if (part == "..") {
+                    if (!segments.empty()) segments.pop_back();
+                } else {
+                    segments.push_back(part);
+                }
+            }
+            if (end == std::string::npos) break;
+            start = end + 1;
+        }
+    };
+
+    pushSegments(directory);
+    pushSegments(href);
+
+    std::ostringstream path;
+    path << '/';
+    for (std::size_t i = 0; i < segments.size(); ++i) {
+        if (i) path << '/';
+        path << segments[i];
+    }
+    return origin + path.str();
+}
+
+static std::string appendQuery(const std::string& url, const std::map<std::string, std::string>& params) {
+    if (params.empty()) return url;
+    std::ostringstream query;
+    bool first = true;
+    for (const auto& [key, value] : params) {
+        if (key.empty()) continue;
+        query << (first ? "" : "&") << urlEncode(key) << '=' << urlEncode(value);
+        first = false;
+    }
+    if (first) return url;
+
+    const auto fragmentPos = url.find('#');
+    const std::string withoutFragment = fragmentPos == std::string::npos ? url : url.substr(0, fragmentPos);
+    const std::string fragment = fragmentPos == std::string::npos ? "" : url.substr(fragmentPos);
+    const char separator = withoutFragment.find('?') == std::string::npos ? '?' : '&';
+    return withoutFragment + separator + query.str() + fragment;
+}
+
+static std::string formFieldName(const std::string& selector, const WebElement& element) {
+    auto name = element.attributes.find("name");
+    if (name != element.attributes.end() && !name->second.empty()) return name->second;
+    if (!element.id.empty()) return element.id;
+    std::string cleaned = selector;
+    if (!cleaned.empty() && (cleaned.front() == '#' || cleaned.front() == '.')) cleaned.erase(cleaned.begin());
+    return cleaned;
 }
 
 class HttpClient {
@@ -620,12 +725,32 @@ BrowserResult AgentBrowser::clickElement(const std::string& selector, SelectorTy
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
     if (!element) return {BrowserActionResult::ELEMENT_NOT_FOUND, "Element not found: " + selector, selector, duration};
     if (!element->isVisible || !element->isEnabled) return {BrowserActionResult::FAILED, "Element is not interactable: " + selector, selector, duration};
+
+    std::optional<std::string> href;
+    if (browser_impl::toLower(element->tag) == "a") {
+        auto it = element->attributes.find("href");
+        if (it != element->attributes.end() && !browser_impl::trim(it->second).empty()) href = it->second;
+    }
+
+    std::string baseUrl;
     {
         std::lock_guard<std::mutex> lock(sessionMutex_);
         auto* session = browser_impl::asSession(browserDriver_);
         if (session) session->lastClickedSelector = selector;
+        baseUrl = currentUrl_;
         stats_.elementsClicked++;
     }
+
+    if (href && !baseUrl.empty()) {
+        const std::string targetUrl = browser_impl::resolveUrl(baseUrl, *href);
+        auto nav = navigateTo(targetUrl);
+        if (nav) {
+            nav.message = "Clicked link " + selector + " and navigated to " + targetUrl;
+            logAction("click_element", nav);
+        }
+        return nav;
+    }
+
     BrowserResult result{BrowserActionResult::SUCCESS, "Clicked element: " + selector, selector, duration};
     logAction("click_element", result);
     return result;
@@ -671,11 +796,47 @@ BrowserResult AgentBrowser::submitForm(const std::string& formSelector) {
     auto element = findElement(formSelector);
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
     if (!element) return {BrowserActionResult::ELEMENT_NOT_FOUND, "Form not found: " + formSelector, formSelector, duration};
+    if (browser_impl::toLower(element->tag) != "form") return {BrowserActionResult::FAILED, "Selector is not a form: " + formSelector, formSelector, duration};
+
+    std::unordered_map<std::string, std::string> formValues;
+    std::unordered_set<std::string> checkedSelectors;
+    std::string baseUrl;
     {
         std::lock_guard<std::mutex> lock(sessionMutex_);
+        auto* session = browser_impl::asSession(browserDriver_);
+        if (session) {
+            formValues = session->formValues;
+            checkedSelectors = session->checkedSelectors;
+        }
+        baseUrl = currentUrl_;
         stats_.formsSubmitted++;
     }
-    return {BrowserActionResult::SUCCESS, "Form submission prepared: " + formSelector, formSelector, duration};
+
+    const auto methodIt = element->attributes.find("method");
+    const std::string method = methodIt == element->attributes.end() ? "get" : browser_impl::toLower(methodIt->second);
+    const auto actionIt = element->attributes.find("action");
+    const std::string action = actionIt == element->attributes.end() || browser_impl::trim(actionIt->second).empty() ? baseUrl : actionIt->second;
+
+    if (method == "get") {
+        std::map<std::string, std::string> queryParams;
+        for (const auto& [selector, value] : formValues) {
+            auto field = findElement(selector);
+            if (!field || !field->isEnabled) continue;
+            queryParams[browser_impl::formFieldName(selector, *field)] = value;
+        }
+        for (const auto& selector : checkedSelectors) {
+            auto field = findElement(selector);
+            if (!field || !field->isEnabled) continue;
+            auto valueIt = field->attributes.find("value");
+            queryParams[browser_impl::formFieldName(selector, *field)] = valueIt == field->attributes.end() || valueIt->second.empty() ? "on" : valueIt->second;
+        }
+        const std::string target = browser_impl::appendQuery(browser_impl::resolveUrl(baseUrl, action), queryParams);
+        auto nav = navigateTo(target);
+        if (nav) nav.message = "Submitted GET form " + formSelector + " to " + target;
+        return nav;
+    }
+
+    return {BrowserActionResult::SUCCESS, "Form submission prepared for unsupported HTTP method: " + method, formSelector, duration};
 }
 
 BrowserResult AgentBrowser::selectOption(const std::string& selector, const std::string& value) {

--- a/cpp/tests/src/test_agentbrowser.cpp
+++ b/cpp/tests/src/test_agentbrowser.cpp
@@ -284,7 +284,11 @@ private:
         stream >> method >> path;
 
         int code = 200;
-        auto it = routes_.find(path);
+        std::string lookupPath = path;
+        if (auto query = lookupPath.find('?'); query != std::string::npos) lookupPath = lookupPath.substr(0, query);
+        if (auto fragment = lookupPath.find('#'); fragment != std::string::npos) lookupPath = lookupPath.substr(0, fragment);
+
+        auto it = routes_.find(lookupPath);
         std::string body;
         if (it == routes_.end()) {
             code = 404;
@@ -326,12 +330,14 @@ TEST_F(AgentBrowserTest, RealHttpNavigationSelectorsFormsArtifactsAndHistory) {
               <body>
                 <h1 id="headline">AgentBrowser retrieved deterministic HTML</h1>
                 <a id="cta" class="primary" href="/second.html">Continue to second page</a>
-                <form id="login-form"><input id="name" name="name" value=""><input id="agree" type="checkbox"></form>
+                <form id="login-form" method="get" action="/submitted.html"><input id="name" name="name" value=""><input id="agree" name="agree" type="checkbox"></form>
                 <img src="/asset.png" alt="fixture">
               </body>
             </html>)HTML"},
         {"/second.html", R"HTML(
-            <html><head><title>Second Fixture</title></head><body><p class="status">Second page loaded</p></body></html>)HTML"}
+            <html><head><title>Second Fixture</title></head><body><p class="status">Second page loaded</p></body></html>)HTML"},
+        {"/submitted.html", R"HTML(
+            <html><head><title>Submitted Fixture</title></head><body><p class="submitted">Submitted page loaded</p></body></html>)HTML"}
     });
 
     AgentBrowser browser(config_);
@@ -354,15 +360,32 @@ TEST_F(AgentBrowserTest, RealHttpNavigationSelectorsFormsArtifactsAndHistory) {
     EXPECT_EQ(cta->tag, "a");
     EXPECT_EQ(cta->attributes["href"], "/second.html");
     EXPECT_NE(cta->text.find("Continue"), std::string::npos);
-    EXPECT_GE(browser.findElements("a").size(), 1u);
+     EXPECT_GE(browser.findElements("a").size(), 1u);
     EXPECT_EQ(browser.waitForElement("#cta", 1).result, BrowserActionResult::SUCCESS);
-    EXPECT_EQ(browser.clickElement("#cta").result, BrowserActionResult::SUCCESS);
-
     EXPECT_EQ(browser.typeText("#name", "Ada").result, BrowserActionResult::SUCCESS);
     EXPECT_EQ(browser.clearText("#name").result, BrowserActionResult::SUCCESS);
     EXPECT_EQ(browser.fillForm({{"#name", "Grace"}}).result, BrowserActionResult::SUCCESS);
     EXPECT_EQ(browser.checkCheckbox("#agree", true).result, BrowserActionResult::SUCCESS);
-    EXPECT_EQ(browser.submitForm("#login-form").result, BrowserActionResult::SUCCESS);
+
+    auto submitted = browser.submitForm("#login-form");
+    ASSERT_EQ(submitted.result, BrowserActionResult::SUCCESS) << submitted.message;
+    ASSERT_TRUE(browser.getPageTitle().has_value());
+    EXPECT_EQ(*browser.getPageTitle(), "Submitted Fixture");
+    auto submittedUrl = browser.evaluateJavaScript("location.href");
+    ASSERT_TRUE(submittedUrl.has_value());
+    EXPECT_NE(submittedUrl->find("/submitted.html?"), std::string::npos);
+    EXPECT_NE(submittedUrl->find("agree=on"), std::string::npos);
+    EXPECT_NE(submittedUrl->find("name=Grace"), std::string::npos);
+
+    auto backToForm = browser.goBack();
+    ASSERT_EQ(backToForm.result, BrowserActionResult::SUCCESS) << backToForm.message;
+    ASSERT_TRUE(browser.getPageTitle().has_value());
+    EXPECT_EQ(*browser.getPageTitle(), "ElizaOS Browser Fixture");
+
+    auto clickNav = browser.clickElement("#cta");
+    ASSERT_EQ(clickNav.result, BrowserActionResult::SUCCESS) << clickNav.message;
+    ASSERT_TRUE(browser.getPageTitle().has_value());
+    EXPECT_EQ(*browser.getPageTitle(), "Second Fixture");
 
     const auto tempDir = std::filesystem::temp_directory_path();
     const auto htmlPath = tempDir / "elizaos_agentbrowser_fixture.html";
@@ -374,14 +397,15 @@ TEST_F(AgentBrowserTest, RealHttpNavigationSelectorsFormsArtifactsAndHistory) {
     EXPECT_GT(std::filesystem::file_size(pngPath), 0u);
     EXPECT_FALSE(browser.getScreenshotData().empty());
 
-    auto second = browser.navigateTo(server.url("/second.html"));
-    ASSERT_EQ(second.result, BrowserActionResult::SUCCESS) << second.message;
-    ASSERT_TRUE(browser.getPageTitle().has_value());
-    EXPECT_EQ(*browser.getPageTitle(), "Second Fixture");
     auto back = browser.goBack();
     ASSERT_EQ(back.result, BrowserActionResult::SUCCESS) << back.message;
     ASSERT_TRUE(browser.getPageTitle().has_value());
     EXPECT_EQ(*browser.getPageTitle(), "ElizaOS Browser Fixture");
+
+    auto second = browser.navigateTo(server.url("/second.html"));
+    ASSERT_EQ(second.result, BrowserActionResult::SUCCESS) << second.message;
+    ASSERT_TRUE(browser.getPageTitle().has_value());
+    EXPECT_EQ(*browser.getPageTitle(), "Second Fixture");
 
     auto stats = browser.getStatistics();
     EXPECT_GE(stats.pagesVisited, 2);
@@ -391,5 +415,46 @@ TEST_F(AgentBrowserTest, RealHttpNavigationSelectorsFormsArtifactsAndHistory) {
 
     std::filesystem::remove(htmlPath);
     std::filesystem::remove(pngPath);
+    EXPECT_EQ(browser.shutdown().result, BrowserActionResult::SUCCESS);
+}
+
+TEST_F(AgentBrowserTest, RealHttpRelativeLinkNavigationAndJavaScriptLimits) {
+    LocalHttpServer server({
+        {"/nested/start.html", R"HTML(
+            <html>
+              <head><title>Relative Start</title></head>
+              <body>
+                <a id="relative" href="../second.html?from=relative">Relative traversal</a>
+                <button id="plain-button">No navigation</button>
+              </body>
+            </html>)HTML"},
+        {"/second.html", R"HTML(
+            <html><head><title>Relative Destination</title></head><body><p>Arrived through a relative URL.</p></body></html>)HTML"}
+    });
+
+    AgentBrowser browser(config_);
+    ASSERT_EQ(browser.initialize().result, BrowserActionResult::SUCCESS);
+
+    auto nav = browser.navigateTo(server.url("/nested/start.html"));
+    ASSERT_EQ(nav.result, BrowserActionResult::SUCCESS) << nav.message;
+    ASSERT_TRUE(browser.getPageTitle().has_value());
+    EXPECT_EQ(*browser.getPageTitle(), "Relative Start");
+
+    auto unsupported = browser.executeJavaScript("document.body.append('fake')");
+    EXPECT_EQ(unsupported.result, BrowserActionResult::FAILED);
+    EXPECT_NE(unsupported.message.find("requires a real browser engine"), std::string::npos);
+    EXPECT_EQ(browser.evaluateJavaScript("document.title").value_or(""), "Relative Start");
+
+    auto plainClick = browser.clickElement("#plain-button");
+    EXPECT_EQ(plainClick.result, BrowserActionResult::SUCCESS) << plainClick.message;
+    EXPECT_EQ(browser.getPageTitle().value_or(""), "Relative Start");
+
+    auto linkClick = browser.clickElement("#relative");
+    ASSERT_EQ(linkClick.result, BrowserActionResult::SUCCESS) << linkClick.message;
+    EXPECT_EQ(browser.getPageTitle().value_or(""), "Relative Destination");
+    auto href = browser.evaluateJavaScript("location.href");
+    ASSERT_TRUE(href.has_value());
+    EXPECT_NE(href->find("/second.html?from=relative"), std::string::npos);
+
     EXPECT_EQ(browser.shutdown().result, BrowserActionResult::SUCCESS);
 }


### PR DESCRIPTION
## Summary

This repair strengthens the real AgentBrowser implementation by replacing extraction-only interaction stubs with HTTP-backed behavior where the parser-mode browser can truthfully cross real boundaries.

## Changes

- Resolve absolute, root-relative, path-relative, query-only, and fragment-only URLs against the current page.
- Make anchor clicks navigate through real fetched pages instead of only recording clicked selectors.
- Make GET form submissions encode enabled named fields and checked checkbox controls, then navigate to the resolved action URL.
- Preserve explicit unsupported semantics for non-rendering parser-mode limitations such as JavaScript execution.
- Expand deterministic local HTTP E2E coverage for link traversal, GET form submission, checked controls, history, statistics, and JavaScript limits.

## Validation

- `cmake --build build --target real_agentbrowser_test real_agentcomms_test -j2`
- `ctest -R '^(real_agentbrowser_test|real_agentcomms_test)$' --output-on-failure`

Both real autonomy tests passed locally.
