### PR TITLE
Strengthen API client boundary contract

### DIFF
--- a/cpp/packages/applications/eliza/packages/api-client/src/client.cpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/client.cpp
@@ -1,11 +1,104 @@
 #include "client.hpp"
 
+#include <stdexcept>
+
 namespace elizaos {
 namespace eliza_api_client {
+namespace {
+
+constexpr int kDefaultTimeoutMs = 30000;
+
+bool startsWith(const std::string& value, const std::string& prefix) {
+    return value.size() >= prefix.size() &&
+           value.compare(0, prefix.size(), prefix) == 0;
+}
+
+bool isHttpUrl(const std::string& value) {
+    return startsWith(value, "http://") || startsWith(value, "https://");
+}
+
+std::string stringFromKey(const nlohmann::json& config,
+                          const std::vector<std::string>& keys) {
+    for (const auto& key : keys) {
+        auto it = config.find(key);
+        if (it != config.end() && it->is_string()) {
+            return it->get<std::string>();
+        }
+    }
+    return {};
+}
+
+int timeoutFromConfig(const nlohmann::json& config) {
+    for (const auto& key : {"timeoutMs", "timeout_ms"}) {
+        auto it = config.find(key);
+        if (it == config.end() || it->is_null()) {
+            continue;
+        }
+        if (!it->is_number_integer()) {
+            throw std::invalid_argument("API client timeout must be an integer number of milliseconds");
+        }
+        int value = it->get<int>();
+        if (value <= 0) {
+            throw std::invalid_argument("API client timeout must be positive");
+        }
+        return value;
+    }
+    return kDefaultTimeoutMs;
+}
+
+std::string normalizeBaseUrl(std::string base_url) {
+    while (!base_url.empty() && base_url.back() == '/') {
+        base_url.pop_back();
+    }
+    if (base_url.empty()) {
+        throw std::invalid_argument("API client baseUrl must not be empty");
+    }
+    if (!isHttpUrl(base_url)) {
+        throw std::invalid_argument("API client baseUrl must start with http:// or https://");
+    }
+    return base_url;
+}
+
+std::map<std::string, std::string> headersFromConfig(const nlohmann::json& config) {
+    std::map<std::string, std::string> headers;
+    auto it = config.find("headers");
+    if (it == config.end() || !it->is_object()) {
+        return headers;
+    }
+
+    for (auto header = it->begin(); header != it->end(); ++header) {
+        if (header.value().is_string()) {
+            headers.emplace(header.key(), header.value().get<std::string>());
+        }
+    }
+    return headers;
+}
+
+} // namespace
 
 bool Client::initialize(const nlohmann::json& config) {
     if (initialized_) return true;
+
+    const std::string configured_base_url =
+        stringFromKey(config, {"baseUrl", "base_url"});
+    if (configured_base_url.empty()) {
+        throw std::invalid_argument("API client requires baseUrl or base_url");
+    }
+
+    const std::string normalized_base_url = normalizeBaseUrl(configured_base_url);
+    const int configured_timeout_ms = timeoutFromConfig(config);
+    const std::string configured_api_key =
+        stringFromKey(config, {"apiKey", "api_key"});
+    const std::string configured_bearer_token =
+        stringFromKey(config, {"bearerToken", "bearer_token"});
+    const auto configured_headers = headersFromConfig(config);
+
     config_ = config;
+    base_url_ = normalized_base_url;
+    timeout_ms_ = configured_timeout_ms;
+    api_key_ = configured_api_key;
+    bearer_token_ = configured_bearer_token;
+    default_headers_ = configured_headers;
     initialized_ = true;
     return true;
 }
@@ -13,13 +106,44 @@ bool Client::initialize(const nlohmann::json& config) {
 void Client::shutdown() {
     initialized_ = false;
     config_ = {};
+    base_url_.clear();
+    timeout_ms_ = kDefaultTimeoutMs;
+    api_key_.clear();
+    bearer_token_.clear();
+    default_headers_.clear();
 }
 
 nlohmann::json Client::getStatus() const {
     nlohmann::json status;
     status["name"] = getName();
     status["initialized"] = initialized_;
+    status["baseUrl"] = initialized_ ? nlohmann::json(base_url_) : nlohmann::json(nullptr);
+    status["timeoutMs"] = timeout_ms_;
+    status["hasApiKey"] = hasApiKey();
+    status["hasBearerToken"] = hasBearerToken();
+    status["hasAuth"] = hasAuth();
+    status["headerCount"] = default_headers_.size();
+    status["defaultHeaders"] = default_headers_;
     return status;
+}
+
+std::string Client::resolveEndpoint(const std::string& path) const {
+    if (!initialized_) {
+        throw std::logic_error("API client must be initialized before resolving endpoints");
+    }
+    if (path.empty() || path == "/") {
+        return base_url_;
+    }
+    if (isHttpUrl(path)) {
+        return path;
+    }
+    if (path.front() == '?') {
+        return base_url_ + path;
+    }
+    if (path.front() == '/') {
+        return base_url_ + path;
+    }
+    return base_url_ + "/" + path;
 }
 
 } // namespace eliza_api_client

--- a/cpp/packages/applications/eliza/packages/api-client/src/client.hpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/client.hpp
@@ -24,9 +24,25 @@ public:
     bool isInitialized() const { return initialized_; }
     const nlohmann::json& getConfig() const { return config_; }
 
+    const std::string& getBaseUrl() const { return base_url_; }
+    int getTimeoutMs() const { return timeout_ms_; }
+    bool hasApiKey() const { return !api_key_.empty(); }
+    bool hasBearerToken() const { return !bearer_token_.empty(); }
+    bool hasAuth() const { return hasApiKey() || hasBearerToken(); }
+    const std::map<std::string, std::string>& getDefaultHeaders() const {
+        return default_headers_;
+    }
+
+    std::string resolveEndpoint(const std::string& path) const;
+
 private:
     nlohmann::json config_;
     bool initialized_ = false;
+    std::string base_url_;
+    int timeout_ms_ = 30000;
+    std::string api_key_;
+    std::string bearer_token_;
+    std::map<std::string, std::string> default_headers_;
 };
 
 } // namespace eliza_api_client

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -317,6 +317,24 @@ target_link_libraries(public_header_forwarding_test
 )
 add_test(NAME public_header_forwarding_test COMMAND public_header_forwarding_test)
 
+# Focused validation for the application-level Eliza API client boundary.
+# This catches regressions in URL normalization, endpoint derivation, redacted
+# auth status, timeout handling, and deterministic shutdown semantics.
+add_executable(api_client_real_test api_client_real_test.cpp)
+target_include_directories(api_client_real_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/cpp/packages/applications/eliza/packages/api-client/src
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/cpp/include
+)
+target_link_libraries(api_client_real_test
+    elizaos-eliza-api-client
+    gtest
+    gtest_main
+    nlohmann_json::nlohmann_json
+    Threads::Threads
+)
+add_test(NAME api_client_real_test COMMAND api_client_real_test)
+
 # ============================================================================
 # KSM focused canonical validation target
 # ============================================================================
@@ -344,6 +362,7 @@ set(ELIZAOS_KSM_CANONICAL_TEST_TARGETS
     real_cognitive_primitives_test
     plugin_specification_test
     public_header_forwarding_test
+    api_client_real_test
 )
 
 add_custom_target(ksm_canonical_tests

--- a/cpp/tests/api_client_real_test.cpp
+++ b/cpp/tests/api_client_real_test.cpp
@@ -1,0 +1,114 @@
+#include <gtest/gtest.h>
+
+#include "client.hpp"
+
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+
+using elizaos::eliza_api_client::Client;
+
+TEST(ApiClientRealTest, InitializesWithCanonicalBaseUrlAndStatusSnapshot) {
+    Client client;
+
+    nlohmann::json config = {
+        {"baseUrl", "https://agent.example.test/api/"},
+        {"timeoutMs", 12000},
+        {"headers", {
+            {"X-Agent", "eliza"},
+            {"X-Number-Ignored", 7}
+        }}
+    };
+
+    ASSERT_TRUE(client.initialize(config));
+    EXPECT_TRUE(client.isInitialized());
+    EXPECT_EQ(client.getBaseUrl(), "https://agent.example.test/api");
+    EXPECT_EQ(client.getTimeoutMs(), 12000);
+    ASSERT_EQ(client.getDefaultHeaders().size(), 1u);
+    EXPECT_EQ(client.getDefaultHeaders().at("X-Agent"), "eliza");
+
+    const auto status = client.getStatus();
+    EXPECT_EQ(status.at("name"), "client");
+    EXPECT_EQ(status.at("initialized"), true);
+    EXPECT_EQ(status.at("baseUrl"), "https://agent.example.test/api");
+    EXPECT_EQ(status.at("timeoutMs"), 12000);
+    EXPECT_EQ(status.at("headerCount"), 1u);
+    EXPECT_EQ(status.at("defaultHeaders").at("X-Agent"), "eliza");
+}
+
+TEST(ApiClientRealTest, ResolvesRelativeRootQueryAndAbsoluteEndpoints) {
+    Client client;
+    ASSERT_TRUE(client.initialize({{"base_url", "http://localhost:3000///"}}));
+
+    EXPECT_EQ(client.resolveEndpoint(""), "http://localhost:3000");
+    EXPECT_EQ(client.resolveEndpoint("/"), "http://localhost:3000");
+    EXPECT_EQ(client.resolveEndpoint("agents"), "http://localhost:3000/agents");
+    EXPECT_EQ(client.resolveEndpoint("/agents/42"), "http://localhost:3000/agents/42");
+    EXPECT_EQ(client.resolveEndpoint("?health=true"), "http://localhost:3000?health=true");
+    EXPECT_EQ(client.resolveEndpoint("https://override.example/status"),
+              "https://override.example/status");
+}
+
+TEST(ApiClientRealTest, RedactsAuthMaterialFromStatus) {
+    Client client;
+    ASSERT_TRUE(client.initialize({
+        {"baseUrl", "https://secure.example.test"},
+        {"apiKey", "sk-secret-value"},
+        {"bearer_token", "bearer-secret-value"}
+    }));
+
+    EXPECT_TRUE(client.hasApiKey());
+    EXPECT_TRUE(client.hasBearerToken());
+    EXPECT_TRUE(client.hasAuth());
+
+    const std::string status_dump = client.getStatus().dump();
+    EXPECT_NE(status_dump.find("\"hasApiKey\":true"), std::string::npos);
+    EXPECT_NE(status_dump.find("\"hasBearerToken\":true"), std::string::npos);
+    EXPECT_EQ(status_dump.find("sk-secret-value"), std::string::npos);
+    EXPECT_EQ(status_dump.find("bearer-secret-value"), std::string::npos);
+}
+
+TEST(ApiClientRealTest, RejectsMissingInvalidBaseUrlAndInvalidTimeout) {
+    Client client;
+
+    EXPECT_THROW(client.initialize({}), std::invalid_argument);
+    EXPECT_THROW(client.initialize({{"baseUrl", ""}}), std::invalid_argument);
+    EXPECT_THROW(client.initialize({{"baseUrl", "localhost:3000"}}), std::invalid_argument);
+    EXPECT_THROW(client.initialize({{"baseUrl", "ftp://example.test"}}), std::invalid_argument);
+    EXPECT_THROW(client.initialize({{"baseUrl", "https://example.test"}, {"timeoutMs", 0}}),
+                 std::invalid_argument);
+    EXPECT_THROW(client.initialize({{"baseUrl", "https://example.test"}, {"timeoutMs", "slow"}}),
+                 std::invalid_argument);
+
+    EXPECT_FALSE(client.isInitialized());
+    EXPECT_EQ(client.getStatus().at("initialized"), false);
+    EXPECT_TRUE(client.getStatus().at("baseUrl").is_null());
+}
+
+TEST(ApiClientRealTest, ShutdownClearsDerivedRuntimeState) {
+    Client client;
+    ASSERT_TRUE(client.initialize({
+        {"baseUrl", "https://agent.example.test"},
+        {"api_key", "secret"},
+        {"timeout_ms", 5000},
+        {"headers", {{"X-Agent", "eliza"}}}
+    }));
+
+    client.shutdown();
+
+    EXPECT_FALSE(client.isInitialized());
+    EXPECT_EQ(client.getBaseUrl(), "");
+    EXPECT_EQ(client.getTimeoutMs(), 30000);
+    EXPECT_FALSE(client.hasAuth());
+    EXPECT_TRUE(client.getDefaultHeaders().empty());
+    EXPECT_THROW(client.resolveEndpoint("agents"), std::logic_error);
+}
+
+TEST(ApiClientRealTest, InitializeIsIdempotentAfterSuccessfulInitialization) {
+    Client client;
+    ASSERT_TRUE(client.initialize({{"baseUrl", "https://first.example.test"}}));
+    ASSERT_TRUE(client.initialize({{"baseUrl", "https://second.example.test"}}));
+
+    EXPECT_EQ(client.getBaseUrl(), "https://first.example.test");
+    EXPECT_EQ(client.resolveEndpoint("status"), "https://first.example.test/status");
+}


### PR DESCRIPTION
## Summary

This KSM cycle germinates the Eliza API-client center from lifecycle-only scaffolding into a deterministic boundary contract. The repair adds canonical base URL normalization, endpoint resolution, timeout handling, redacted auth metadata, default header state, and shutdown clearing semantics.

## Validation

- Built `elizaos-eliza-api-client`
- Built focused `api_client_real_test`
- Built `ksm_canonical_tests`
- Ran focused regression set: `ctest -R "api_client_real_test|public_header_forwarding_test|real_agentbrowser_test|real_agentcomms_test" --output-on-failure`
- Ran full KSM canonical suite: `ctest -L ksm --output-on-failure` — 19/19 passed

## Notes

This intentionally does not add live outbound HTTP transport yet. It creates the stable validated seam that future API transport code can use without leaking secrets or carrying stale runtime state.