### PR TITLE
Repair KSM autonomy parity and header validation

### DIFF
--- a/cpp/external/evolutionary/src/evolutionary.cpp
+++ b/cpp/external/evolutionary/src/evolutionary.cpp
@@ -146,14 +146,19 @@ Individual Individual::crossover(const Individual& parent1, const Individual& pa
         return Individual(nullptr);
     }
     
-    // Create offspring by copying parent1's program
-    auto offspring = std::make_shared<ProgramNode>(*parent1.program_);
+    // Create offspring by deep-copying parent1's program. A shallow ProgramNode copy
+    // would alias child subtrees back into parent1, so replacing a descendant during
+    // crossover could mutate a parent and make tests non-deterministic across runs.
+    auto offspring = parent1.program_->clone();
     
-    // Perform subtree crossover
+    // Perform subtree crossover.
     std::random_device rd;
     std::mt19937 gen(rd());
     
-    // Select random subtree from parent1 to replace
+    // Select candidate subtrees from the cloned offspring. Prefer non-root
+    // replacement sites when parent1 has descendants so the offspring keeps a
+    // usable top-level executable structure instead of occasionally collapsing to
+    // a terminal constant.
     std::vector<std::shared_ptr<ProgramNode>> subtrees1;
     std::function<void(std::shared_ptr<ProgramNode>)> collectSubtrees1 = 
         [&](std::shared_ptr<ProgramNode> node) {
@@ -164,7 +169,7 @@ Individual Individual::crossover(const Individual& parent1, const Individual& pa
         };
     collectSubtrees1(offspring);
     
-    // Select random subtree from parent2 to insert
+    // Select random subtree from parent2 to insert.
     std::vector<std::shared_ptr<ProgramNode>> subtrees2;
     std::function<void(std::shared_ptr<ProgramNode>)> collectSubtrees2 = 
         [&](std::shared_ptr<ProgramNode> node) {
@@ -176,13 +181,14 @@ Individual Individual::crossover(const Individual& parent1, const Individual& pa
     collectSubtrees2(parent2.program_);
     
     if (!subtrees1.empty() && !subtrees2.empty()) {
-        std::uniform_int_distribution<size_t> dist1(0, subtrees1.size() - 1);
+        const size_t minReplaceIndex = subtrees1.size() > 1 ? 1 : 0;
+        std::uniform_int_distribution<size_t> dist1(minReplaceIndex, subtrees1.size() - 1);
         std::uniform_int_distribution<size_t> dist2(0, subtrees2.size() - 1);
         
         size_t replaceIndex = dist1(gen);
         size_t insertIndex = dist2(gen);
         
-        // Replace subtree
+        // Replace subtree contents with an independent clone from parent2.
         auto& replaceNode = subtrees1[replaceIndex];
         auto& insertNode = subtrees2[insertIndex];
         

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -317,6 +317,75 @@ target_link_libraries(public_header_forwarding_test
 )
 add_test(NAME public_header_forwarding_test COMMAND public_header_forwarding_test)
 
+add_executable(public_header_forwarding_all_test
+    public_header_forwarding_all_test.cpp
+    public_header_forwarding_headers/agentaction_hpp_test.cpp
+    public_header_forwarding_headers/agentagenda_hpp_test.cpp
+    public_header_forwarding_headers/agentbrowser_hpp_test.cpp
+    public_header_forwarding_headers/agentcomms_hpp_test.cpp
+    public_header_forwarding_headers/agentlogger_hpp_test.cpp
+    public_header_forwarding_headers/agentloop_hpp_test.cpp
+    public_header_forwarding_headers/agentmemory_hpp_test.cpp
+    public_header_forwarding_headers/agentshell_hpp_test.cpp
+    public_header_forwarding_headers/attention_hpp_test.cpp
+    public_header_forwarding_headers/auto_fun_hpp_test.cpp
+    public_header_forwarding_headers/autofun_idl_hpp_test.cpp
+    public_header_forwarding_headers/autonomous_starter_hpp_test.cpp
+    public_header_forwarding_headers/awesome_eliza_hpp_test.cpp
+    public_header_forwarding_headers/brandkit_hpp_test.cpp
+    public_header_forwarding_headers/characterfile_hpp_test.cpp
+    public_header_forwarding_headers/characters_hpp_test.cpp
+    public_header_forwarding_headers/classified_hpp_test.cpp
+    public_header_forwarding_headers/cognitive_bridge_hpp_test.cpp
+    public_header_forwarding_headers/comprehensive_e2e_hpp_test.cpp
+    public_header_forwarding_headers/core_hpp_test.cpp
+    public_header_forwarding_headers/discord_summarizer_hpp_test.cpp
+    public_header_forwarding_headers/discrub_ext_hpp_test.cpp
+    public_header_forwarding_headers/easycompletion_hpp_test.cpp
+    public_header_forwarding_headers/eliza_hpp_test.cpp
+    public_header_forwarding_headers/eliza_3d_hyperfy_starter_hpp_test.cpp
+    public_header_forwarding_headers/eliza_nextjs_starter_hpp_test.cpp
+    public_header_forwarding_headers/eliza_plugin_starter_hpp_test.cpp
+    public_header_forwarding_headers/eliza_starter_hpp_test.cpp
+    public_header_forwarding_headers/elizaos_hpp_test.cpp
+    public_header_forwarding_headers/elizaos_github_io_hpp_test.cpp
+    public_header_forwarding_headers/elizas_list_hpp_test.cpp
+    public_header_forwarding_headers/elizas_world_hpp_test.cpp
+    public_header_forwarding_headers/embodiment_hpp_test.cpp
+    public_header_forwarding_headers/evolutionary_hpp_test.cpp
+    public_header_forwarding_headers/goal_manager_hpp_test.cpp
+    public_header_forwarding_headers/hat_hpp_test.cpp
+    public_header_forwarding_headers/hats_hpp_test.cpp
+    public_header_forwarding_headers/knowledge_hpp_test.cpp
+    public_header_forwarding_headers/livevideochat_hpp_test.cpp
+    public_header_forwarding_headers/ljspeechtools_hpp_test.cpp
+    public_header_forwarding_headers/mcp_gateway_hpp_test.cpp
+    public_header_forwarding_headers/ontogenesis_hpp_test.cpp
+    public_header_forwarding_headers/otaku_hpp_test.cpp
+    public_header_forwarding_headers/otc_agent_hpp_test.cpp
+    public_header_forwarding_headers/plugin_specification_hpp_test.cpp
+    public_header_forwarding_headers/plugins_automation_hpp_test.cpp
+    public_header_forwarding_headers/registry_hpp_test.cpp
+    public_header_forwarding_headers/spartan_hpp_test.cpp
+    public_header_forwarding_headers/sweagent_hpp_test.cpp
+    public_header_forwarding_headers/the_org_hpp_test.cpp
+    public_header_forwarding_headers/trust_scoreboard_hpp_test.cpp
+    public_header_forwarding_headers/vercel_api_hpp_test.cpp
+    public_header_forwarding_headers/website_hpp_test.cpp
+    public_header_forwarding_headers/workgroups_hpp_test.cpp
+)
+target_include_directories(public_header_forwarding_all_test BEFORE PRIVATE
+    ${CMAKE_SOURCE_DIR}/cpp/include
+    ${CMAKE_SOURCE_DIR}/include
+)
+target_link_libraries(public_header_forwarding_all_test
+    nlohmann_json::nlohmann_json
+    gtest
+    gtest_main
+    Threads::Threads
+)
+add_test(NAME public_header_forwarding_all_test COMMAND public_header_forwarding_all_test)
+
 # ============================================================================
 # KSM focused canonical validation target
 # ============================================================================
@@ -344,6 +413,7 @@ set(ELIZAOS_KSM_CANONICAL_TEST_TARGETS
     real_cognitive_primitives_test
     plugin_specification_test
     public_header_forwarding_test
+    public_header_forwarding_all_test
 )
 
 add_custom_target(ksm_canonical_tests

--- a/cpp/tests/public_header_forwarding_all_test.cpp
+++ b/cpp/tests/public_header_forwarding_all_test.cpp
@@ -1,0 +1,14 @@
+#include <gtest/gtest.h>
+
+// Aggregator translation unit for the generated per-header forwarding compile tests.
+// Individual headers are compiled in isolated translation units under
+// public_header_forwarding_headers/ to catch missing dependencies without
+// manufacturing cross-header symbol collisions.
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, GeneratedPerHeaderSourcesAreLinked) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/agentaction_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/agentaction_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/agentaction.hpp>.
+#include <elizaos/agentaction.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, agentaction_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/agentagenda_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/agentagenda_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/agentagenda.hpp>.
+#include <elizaos/agentagenda.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, agentagenda_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/agentbrowser_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/agentbrowser_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/agentbrowser.hpp>.
+#include <elizaos/agentbrowser.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, agentbrowser_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/agentcomms_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/agentcomms_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/agentcomms.hpp>.
+#include <elizaos/agentcomms.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, agentcomms_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/agentlogger_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/agentlogger_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/agentlogger.hpp>.
+#include <elizaos/agentlogger.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, agentlogger_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/agentloop_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/agentloop_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/agentloop.hpp>.
+#include <elizaos/agentloop.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, agentloop_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/agentmemory_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/agentmemory_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/agentmemory.hpp>.
+#include <elizaos/agentmemory.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, agentmemory_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/agentshell_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/agentshell_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/agentshell.hpp>.
+#include <elizaos/agentshell.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, agentshell_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/attention_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/attention_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/attention.hpp>.
+#include <elizaos/attention.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, attention_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/auto_fun_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/auto_fun_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/auto_fun.hpp>.
+#include <elizaos/auto_fun.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, auto_fun_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/autofun_idl_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/autofun_idl_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/autofun_idl.hpp>.
+#include <elizaos/autofun_idl.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, autofun_idl_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/autonomous_starter_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/autonomous_starter_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/autonomous_starter.hpp>.
+#include <elizaos/autonomous_starter.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, autonomous_starter_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/awesome_eliza_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/awesome_eliza_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/awesome_eliza.hpp>.
+#include <elizaos/awesome_eliza.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, awesome_eliza_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/brandkit_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/brandkit_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/brandkit.hpp>.
+#include <elizaos/brandkit.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, brandkit_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/characterfile_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/characterfile_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/characterfile.hpp>.
+#include <elizaos/characterfile.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, characterfile_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/characters_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/characters_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/characters.hpp>.
+#include <elizaos/characters.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, characters_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/classified_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/classified_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/classified.hpp>.
+#include <elizaos/classified.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, classified_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/cognitive_bridge_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/cognitive_bridge_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/cognitive_bridge.hpp>.
+#include <elizaos/cognitive_bridge.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, cognitive_bridge_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/comprehensive_e2e_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/comprehensive_e2e_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/comprehensive_e2e.hpp>.
+#include <elizaos/comprehensive_e2e.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, comprehensive_e2e_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/core_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/core_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/core.hpp>.
+#include <elizaos/core.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, core_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/discord_summarizer_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/discord_summarizer_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/discord_summarizer.hpp>.
+#include <elizaos/discord_summarizer.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, discord_summarizer_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/discrub_ext_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/discrub_ext_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/discrub_ext.hpp>.
+#include <elizaos/discrub_ext.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, discrub_ext_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/easycompletion_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/easycompletion_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/easycompletion.hpp>.
+#include <elizaos/easycompletion.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, easycompletion_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/eliza_3d_hyperfy_starter_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/eliza_3d_hyperfy_starter_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/eliza_3d_hyperfy_starter.hpp>.
+#include <elizaos/eliza_3d_hyperfy_starter.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, eliza_3d_hyperfy_starter_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/eliza_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/eliza_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/eliza.hpp>.
+#include <elizaos/eliza.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, eliza_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/eliza_nextjs_starter_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/eliza_nextjs_starter_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/eliza_nextjs_starter.hpp>.
+#include <elizaos/eliza_nextjs_starter.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, eliza_nextjs_starter_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/eliza_plugin_starter_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/eliza_plugin_starter_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/eliza_plugin_starter.hpp>.
+#include <elizaos/eliza_plugin_starter.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, eliza_plugin_starter_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/eliza_starter_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/eliza_starter_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/eliza_starter.hpp>.
+#include <elizaos/eliza_starter.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, eliza_starter_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/elizaos_github_io_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/elizaos_github_io_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/elizaos_github_io.hpp>.
+#include <elizaos/elizaos_github_io.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, elizaos_github_io_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/elizaos_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/elizaos_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/elizaos.hpp>.
+#include <elizaos/elizaos.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, elizaos_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/elizas_list_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/elizas_list_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/elizas_list.hpp>.
+#include <elizaos/elizas_list.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, elizas_list_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/elizas_world_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/elizas_world_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/elizas_world.hpp>.
+#include <elizaos/elizas_world.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, elizas_world_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/embodiment_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/embodiment_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/embodiment.hpp>.
+#include <elizaos/embodiment.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, embodiment_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/evolutionary_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/evolutionary_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/evolutionary.hpp>.
+#include <elizaos/evolutionary.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, evolutionary_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/goal_manager_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/goal_manager_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/goal_manager.hpp>.
+#include <elizaos/goal_manager.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, goal_manager_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/hat_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/hat_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/hat.hpp>.
+#include <elizaos/hat.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, hat_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/hats_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/hats_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/hats.hpp>.
+#include <elizaos/hats.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, hats_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/knowledge_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/knowledge_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/knowledge.hpp>.
+#include <elizaos/knowledge.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, knowledge_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/livevideochat_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/livevideochat_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/livevideochat.hpp>.
+#include <elizaos/livevideochat.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, livevideochat_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/ljspeechtools_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/ljspeechtools_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/ljspeechtools.hpp>.
+#include <elizaos/ljspeechtools.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, ljspeechtools_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/mcp_gateway_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/mcp_gateway_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/mcp_gateway.hpp>.
+#include <elizaos/mcp_gateway.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, mcp_gateway_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/ontogenesis_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/ontogenesis_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/ontogenesis.hpp>.
+#include <elizaos/ontogenesis.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, ontogenesis_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/otaku_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/otaku_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/otaku.hpp>.
+#include <elizaos/otaku.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, otaku_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/otc_agent_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/otc_agent_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/otc_agent.hpp>.
+#include <elizaos/otc_agent.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, otc_agent_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/plugin_specification_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/plugin_specification_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/plugin_specification.hpp>.
+#include <elizaos/plugin_specification.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, plugin_specification_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/plugins_automation_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/plugins_automation_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/plugins_automation.hpp>.
+#include <elizaos/plugins_automation.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, plugins_automation_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/registry_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/registry_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/registry.hpp>.
+#include <elizaos/registry.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, registry_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/spartan_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/spartan_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/spartan.hpp>.
+#include <elizaos/spartan.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, spartan_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/sweagent_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/sweagent_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/sweagent.hpp>.
+#include <elizaos/sweagent.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, sweagent_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/the_org_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/the_org_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/the_org.hpp>.
+#include <elizaos/the_org.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, the_org_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/trust_scoreboard_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/trust_scoreboard_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/trust_scoreboard.hpp>.
+#include <elizaos/trust_scoreboard.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, trust_scoreboard_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/vercel_api_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/vercel_api_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/vercel_api.hpp>.
+#include <elizaos/vercel_api.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, vercel_api_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/website_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/website_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/website.hpp>.
+#include <elizaos/website.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, website_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace

--- a/cpp/tests/public_header_forwarding_headers/workgroups_hpp_test.cpp
+++ b/cpp/tests/public_header_forwarding_headers/workgroups_hpp_test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+// Isolated public-header compile regression for <elizaos/workgroups.hpp>.
+#include <elizaos/workgroups.hpp>
+
+namespace {
+
+TEST(PublicHeaderForwardingAllTest, workgroups_hpp_CompilesInIsolation) {
+    SUCCEED();
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

This repair cycle strengthens the canonical ElizaOS C++ KSM/autonomy validation lane and keeps the flattened and canonical trees aligned where their compatibility surfaces diverged.

## Changes

- Fixes `Individual::crossover` to deep-clone parent programs before subtree replacement, preventing parent alias mutation and removing nondeterministic root-collapse failures.
- Adds comprehensive per-header public forwarding compile coverage to the canonical KSM target.
- Preserves and validates flattened `<elizaos/...>` compatibility wrappers where applicable.
- Synchronizes the focused real autonomy test lane without replacing real implementations with mocks.

## Validation

- `cmake --build build-ksm --target ksm_canonical_tests -j2`
- `ctest --test-dir build-ksm -L ksm --output-on-failure`

Both `hurdcog/elizaos.cpp` and `o9nn/elizaos-cpp` passed all 19 canonical KSM tests after the crossover repair.
