### PR TITLE
Restore truthful API client transport tests

### DIFF
--- a/cpp/packages/applications/eliza/packages/api-client/CMakeLists.txt
+++ b/cpp/packages/applications/eliza/packages/api-client/CMakeLists.txt
@@ -1,6 +1,9 @@
 # CMakeLists.txt for eliza-api-client
 cmake_minimum_required(VERSION 3.16)
 
+# CurlTransport provides the real HTTP backend for the API client.
+find_package(CURL REQUIRED)
+
 # Collect all source files
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 file(GLOB_RECURSE HEADERS "src/*.hpp" "include/*.hpp")
@@ -18,6 +21,7 @@ if(SOURCES)
     target_link_libraries(elizaos-eliza-api-client
         nlohmann_json::nlohmann_json
         Threads::Threads
+        CURL::libcurl
     )
 
     set_property(TARGET elizaos-eliza-api-client PROPERTY CXX_STANDARD 17)

--- a/cpp/packages/applications/eliza/packages/api-client/src/client.cpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/client.cpp
@@ -108,38 +108,96 @@ std::map<std::string, std::string> redactHeadersForStatus(
 bool Client::initialize(const nlohmann::json& config) {
     if (initialized_) return true;
 
-    const std::string configured_base_url =
-        stringFromKey(config, {"baseUrl", "base_url"});
-    if (configured_base_url.empty()) {
-        throw std::invalid_argument("API client requires baseUrl or base_url");
+    try {
+        const std::string configured_base_url =
+            stringFromKey(config, {"baseUrl", "base_url"});
+        if (configured_base_url.empty()) {
+            setLastError("missing_base_url", "API client requires baseUrl or base_url");
+            throw std::invalid_argument("API client requires baseUrl or base_url");
+        }
+
+        const std::string normalized_base_url = normalizeBaseUrl(configured_base_url);
+        const int configured_timeout_ms = timeoutFromConfig(config);
+        const std::string configured_api_key =
+            stringFromKey(config, {"apiKey", "api_key"});
+        const std::string configured_bearer_token =
+            stringFromKey(config, {"bearerToken", "bearer_token"});
+        const auto configured_headers = headersFromConfig(config);
+
+        config_ = config;
+        base_url_ = normalized_base_url;
+        timeout_ms_ = configured_timeout_ms;
+        api_key_ = configured_api_key;
+        bearer_token_ = configured_bearer_token;
+        default_headers_ = configured_headers;
+
+        // Add authentication headers
+        if (!api_key_.empty()) {
+            default_headers_["X-API-Key"] = api_key_;
+        }
+        if (!bearer_token_.empty()) {
+            default_headers_["Authorization"] = "Bearer " + bearer_token_;
+        }
+
+        // Create and initialize the shared BaseClient
+        baseClient_ = std::make_shared<BaseClient>();
+        
+        nlohmann::json baseClientConfig;
+        baseClientConfig["baseUrl"] = base_url_;
+        baseClientConfig["timeoutMs"] = timeout_ms_;
+        
+        if (!baseClient_->initialize(baseClientConfig)) {
+            setLastError(baseClient_->getLastErrorCode(), baseClient_->getLastErrorMessage());
+            return false;
+        }
+
+        initialized_ = true;
+        clearLastError();
+        return true;
+    } catch (const std::invalid_argument& e) {
+        setLastError("invalid_configuration", e.what());
+        throw;
+    } catch (const std::exception& e) {
+        setLastError("initialization_error", e.what());
+        return false;
     }
-
-    const std::string normalized_base_url = normalizeBaseUrl(configured_base_url);
-    const int configured_timeout_ms = timeoutFromConfig(config);
-    const std::string configured_api_key =
-        stringFromKey(config, {"apiKey", "api_key"});
-    const std::string configured_bearer_token =
-        stringFromKey(config, {"bearerToken", "bearer_token"});
-    const auto configured_headers = headersFromConfig(config);
-
-    config_ = config;
-    base_url_ = normalized_base_url;
-    timeout_ms_ = configured_timeout_ms;
-    api_key_ = configured_api_key;
-    bearer_token_ = configured_bearer_token;
-    default_headers_ = configured_headers;
-    initialized_ = true;
-    return true;
 }
 
 void Client::shutdown() {
+    // Shutdown services
+    if (server_) {
+        server_->shutdown();
+        server_.reset();
+    }
+    if (system_) {
+        system_->shutdown();
+        system_.reset();
+    }
+    if (agents_) {
+        agents_->shutdown();
+        agents_.reset();
+    }
+
+    // Shutdown base client
+    if (baseClient_) {
+        baseClient_->shutdown();
+        baseClient_.reset();
+    }
+
     initialized_ = false;
-    config_ = {};
+    config_ = nlohmann::json::object();
     base_url_.clear();
     timeout_ms_ = kDefaultTimeoutMs;
     api_key_.clear();
     bearer_token_.clear();
     default_headers_.clear();
+    clearLastError();
+}
+
+void Client::setTransport(std::shared_ptr<IHttpTransport> transport) {
+    if (baseClient_) {
+        baseClient_->setTransport(std::move(transport));
+    }
 }
 
 nlohmann::json Client::getStatus() const {
@@ -153,6 +211,23 @@ nlohmann::json Client::getStatus() const {
     status["hasAuth"] = hasAuth();
     status["headerCount"] = default_headers_.size();
     status["defaultHeaders"] = redactHeadersForStatus(default_headers_);
+    status["lastErrorCode"] = lastErrorCode_;
+    status["lastErrorMessage"] = lastErrorMessage_;
+    
+    // Include base client status
+    status["baseClient"] = baseClient_ ? baseClient_->getStatus() : nlohmann::json::object();
+    
+    // Include service statuses if initialized
+    if (server_) {
+        status["services"]["server"] = server_->getStatus();
+    }
+    if (system_) {
+        status["services"]["system"] = system_->getStatus();
+    }
+    if (agents_) {
+        status["services"]["agents"] = agents_->getStatus();
+    }
+    
     return status;
 }
 
@@ -173,6 +248,76 @@ std::string Client::resolveEndpoint(const std::string& path) const {
         return base_url_ + path;
     }
     return base_url_ + "/" + path;
+}
+
+void Client::ensureServicesInitialized() const {
+    if (!initialized_) {
+        throw std::logic_error("Client must be initialized before accessing services");
+    }
+}
+
+Server& Client::server() {
+    ensureServicesInitialized();
+    if (!server_) {
+        server_ = std::make_unique<Server>(baseClient_);
+        server_->initialize(config_);
+    }
+    return *server_;
+}
+
+const Server& Client::server() const {
+    ensureServicesInitialized();
+    if (!server_) {
+        server_ = std::make_unique<Server>(baseClient_);
+        server_->initialize(config_);
+    }
+    return *server_;
+}
+
+System& Client::system() {
+    ensureServicesInitialized();
+    if (!system_) {
+        system_ = std::make_unique<System>(baseClient_);
+        system_->initialize(config_);
+    }
+    return *system_;
+}
+
+const System& Client::system() const {
+    ensureServicesInitialized();
+    if (!system_) {
+        system_ = std::make_unique<System>(baseClient_);
+        system_->initialize(config_);
+    }
+    return *system_;
+}
+
+Agents& Client::agents() {
+    ensureServicesInitialized();
+    if (!agents_) {
+        agents_ = std::make_unique<Agents>(baseClient_);
+        agents_->initialize(config_);
+    }
+    return *agents_;
+}
+
+const Agents& Client::agents() const {
+    ensureServicesInitialized();
+    if (!agents_) {
+        agents_ = std::make_unique<Agents>(baseClient_);
+        agents_->initialize(config_);
+    }
+    return *agents_;
+}
+
+void Client::setLastError(std::string code, std::string message) {
+    lastErrorCode_ = std::move(code);
+    lastErrorMessage_ = std::move(message);
+}
+
+void Client::clearLastError() {
+    lastErrorCode_.clear();
+    lastErrorMessage_.clear();
 }
 
 } // namespace eliza_api_client

--- a/cpp/packages/applications/eliza/packages/api-client/src/client.hpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/client.hpp
@@ -9,20 +9,61 @@
 #include <optional>
 #include <nlohmann/json.hpp>
 
+#include "lib/base-client.hpp"
+#include "services/server.hpp"
+#include "services/system.hpp"
+#include "services/agents.hpp"
+
 namespace elizaos {
 namespace eliza_api_client {
 
+/**
+ * Top-level API client aggregator that provides access to all ElizaOS API services.
+ * 
+ * The Client class:
+ * - Manages a shared BaseClient that all services use
+ * - Provides lazy-initialized service accessors
+ * - Handles authentication and default headers
+ * - Supports both API key and ****** authentication
+ * 
+ * Usage:
+ *   Client client;
+ *   client.initialize({{"baseUrl", "http://localhost:3000"}});
+ *   auto health = client.server().getHealth();
+ *   auto info = client.system().getInfo();
+ */
 class Client {
 public:
     Client() = default;
     ~Client() = default;
 
+    /**
+     * Initialize the client with configuration.
+     * Required config keys:
+     *   - baseUrl or base_url: The API server base URL
+     * Optional config keys:
+     *   - apiKey or api_key: API key for authentication
+     *   - bearerToken or bearer_token: ****** for authentication
+     *   - timeoutMs or timeout_ms: Request timeout in milliseconds (default: 30000)
+     *   - headers: Object with default headers to include in all requests
+     */
     bool initialize(const nlohmann::json& config = {});
+    
+    /**
+     * Shutdown the client and all services.
+     */
     void shutdown();
+    
+    /**
+     * Get the status of the client and all services.
+     */
     nlohmann::json getStatus() const;
+    
     std::string getName() const { return "client"; }
     bool isInitialized() const { return initialized_; }
     const nlohmann::json& getConfig() const { return config_; }
+    const std::string& getLastErrorCode() const { return lastErrorCode_; }
+    const std::string& getLastErrorMessage() const { return lastErrorMessage_; }
 
     const std::string& getBaseUrl() const { return base_url_; }
     int getTimeoutMs() const { return timeout_ms_; }
@@ -35,14 +76,53 @@ public:
 
     std::string resolveEndpoint(const std::string& path) const;
 
+    /**
+     * Get the shared BaseClient instance.
+     */
+    std::shared_ptr<BaseClient> getBaseClient() const { return baseClient_; }
+
+    /**
+     * Set a custom HTTP transport for the shared BaseClient.
+     */
+    void setTransport(std::shared_ptr<IHttpTransport> transport);
+
+    /**
+     * Get the Server service for health and status endpoints.
+     */
+    Server& server();
+    const Server& server() const;
+
+    /**
+     * Get the System service for configuration and metrics endpoints.
+     */
+    System& system();
+    const System& system() const;
+
+    /**
+     * Get the Agents service for agent management endpoints.
+     */
+    Agents& agents();
+    const Agents& agents() const;
+
 private:
-    nlohmann::json config_;
+    void setLastError(std::string code, std::string message);
+    void clearLastError();
+    void ensureServicesInitialized() const;
+
+    nlohmann::json config_ = nlohmann::json::object();
     bool initialized_ = false;
     std::string base_url_;
     int timeout_ms_ = 30000;
     std::string api_key_;
     std::string bearer_token_;
     std::map<std::string, std::string> default_headers_;
+    std::string lastErrorCode_;
+    std::string lastErrorMessage_;
+
+    std::shared_ptr<BaseClient> baseClient_;
+    mutable std::unique_ptr<Server> server_;
+    mutable std::unique_ptr<System> system_;
+    mutable std::unique_ptr<Agents> agents_;
 };
 
 } // namespace eliza_api_client

--- a/cpp/packages/applications/eliza/packages/api-client/src/lib/base-client.cpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/lib/base-client.cpp
@@ -1,25 +1,196 @@
 #include "base-client.hpp"
 
+#include <algorithm>
+#include <cctype>
+#include <utility>
+
 namespace elizaos {
 namespace eliza_api_client {
 
+ApiResult ApiResult::success(HttpResponse response) {
+    ApiResult result;
+    result.ok = true;
+    result.response = std::move(response);
+    return result;
+}
+
+ApiResult ApiResult::failure(std::string code, std::string message, HttpResponse response) {
+    ApiResult result;
+    result.ok = false;
+    result.response = std::move(response);
+    result.errorCode = std::move(code);
+    result.errorMessage = std::move(message);
+    return result;
+}
+
+BaseClient::BaseClient(std::shared_ptr<IHttpTransport> transport)
+    : transport_(std::move(transport)) {}
+
 bool BaseClient::initialize(const nlohmann::json& config) {
-    if (initialized_) return true;
+    if (!validateConfig(config)) {
+        initialized_ = false;
+        configured_ = false;
+        config_ = nlohmann::json::object();
+        baseUrl_.clear();
+        return false;
+    }
+
     config_ = config;
+    if (!config_.contains("baseUrl") && config_.contains("base_url")) {
+        config_["baseUrl"] = config_.at("base_url");
+    }
+    config_["baseUrl"] = baseUrl_;
+    config_["timeoutMs"] = timeoutMs_;
+    config_["maxRetries"] = maxRetries_;
+
+    configured_ = true;
     initialized_ = true;
+    clearLastError();
     return true;
 }
 
 void BaseClient::shutdown() {
     initialized_ = false;
-    config_ = {};
+    configured_ = false;
+    config_ = nlohmann::json::object();
+    baseUrl_.clear();
+    timeoutMs_ = 30000;
+    maxRetries_ = 0;
+    clearLastError();
+}
+
+void BaseClient::setTransport(std::shared_ptr<IHttpTransport> transport) {
+    transport_ = std::move(transport);
+}
+
+ApiResult BaseClient::request(const std::string& method,
+                              const std::string& path,
+                              const nlohmann::json& body,
+                              const std::map<std::string, std::string>& headers) const {
+    if (!initialized_ || !configured_) {
+        return ApiResult::failure("client_not_initialized", "BaseClient must be successfully initialized before requests can be sent.");
+    }
+    if (!transport_) {
+        return ApiResult::failure("transport_missing", "No HTTP transport has been configured for BaseClient.");
+    }
+    if (!transport_->isReady()) {
+        return ApiResult::failure("transport_not_ready", "The configured HTTP transport reports that it is not ready.");
+    }
+
+    HttpRequest request;
+    request.method = method;
+    request.path = path;
+    request.url = buildUrl(path);
+    request.body = body;
+    request.headers = headers;
+    return transport_->send(request);
+}
+
+std::string BaseClient::buildUrl(const std::string& path) const {
+    if (baseUrl_.empty()) {
+        return path;
+    }
+    if (path.empty()) {
+        return baseUrl_;
+    }
+    if (path.rfind("http://", 0) == 0 || path.rfind("https://", 0) == 0) {
+        return path;
+    }
+    if (path.front() == '/') {
+        return baseUrl_ + path;
+    }
+    return baseUrl_ + "/" + path;
 }
 
 nlohmann::json BaseClient::getStatus() const {
     nlohmann::json status;
     status["name"] = getName();
     status["initialized"] = initialized_;
+    status["configured"] = configured_;
+    status["baseUrl"] = baseUrl_;
+    status["timeoutMs"] = timeoutMs_;
+    status["maxRetries"] = maxRetries_;
+    status["transportConfigured"] = static_cast<bool>(transport_);
+    status["transportReady"] = isTransportReady();
+    status["transportName"] = transport_ ? transport_->getName() : "none";
+    status["lastErrorCode"] = lastErrorCode_;
+    status["lastErrorMessage"] = lastErrorMessage_;
     return status;
+}
+
+bool BaseClient::isTransportReady() const {
+    return transport_ && transport_->isReady();
+}
+
+std::string BaseClient::trim(const std::string& value) {
+    auto begin = std::find_if_not(value.begin(), value.end(), [](unsigned char ch) { return std::isspace(ch) != 0; });
+    auto end = std::find_if_not(value.rbegin(), value.rend(), [](unsigned char ch) { return std::isspace(ch) != 0; }).base();
+    if (begin >= end) {
+        return {};
+    }
+    return std::string(begin, end);
+}
+
+std::string BaseClient::normalizeBaseUrl(const std::string& value) {
+    std::string normalized = trim(value);
+    while (normalized.size() > std::string("https://").size() && normalized.back() == '/') {
+        normalized.pop_back();
+    }
+    return normalized;
+}
+
+bool BaseClient::isHttpUrl(const std::string& value) {
+    return value.rfind("http://", 0) == 0 || value.rfind("https://", 0) == 0;
+}
+
+bool BaseClient::validateConfig(const nlohmann::json& config) {
+    if (!config.is_object()) {
+        setLastError("invalid_config", "BaseClient configuration must be a JSON object.");
+        return false;
+    }
+
+    const auto baseUrlIt = config.find("baseUrl") != config.end() ? config.find("baseUrl") : config.find("base_url");
+    if (baseUrlIt == config.end() || !baseUrlIt->is_string()) {
+        setLastError("base_url_missing", "BaseClient requires a string baseUrl or base_url field.");
+        return false;
+    }
+
+    const std::string normalizedBaseUrl = normalizeBaseUrl(baseUrlIt->get<std::string>());
+    if (normalizedBaseUrl.empty()) {
+        setLastError("base_url_empty", "BaseClient baseUrl must not be empty.");
+        return false;
+    }
+    if (!isHttpUrl(normalizedBaseUrl)) {
+        setLastError("base_url_invalid", "BaseClient baseUrl must start with http:// or https://.");
+        return false;
+    }
+
+    int timeoutMs = config.value("timeoutMs", config.value("timeout_ms", 30000));
+    if (timeoutMs <= 0) {
+        setLastError("timeout_invalid", "BaseClient timeoutMs must be greater than zero.");
+        return false;
+    }
+
+    int maxRetries = config.value("maxRetries", config.value("max_retries", 0));
+    if (maxRetries < 0) {
+        setLastError("retries_invalid", "BaseClient maxRetries must not be negative.");
+        return false;
+    }
+
+    baseUrl_ = normalizedBaseUrl;
+    timeoutMs_ = timeoutMs;
+    maxRetries_ = maxRetries;
+    return true;
+}
+
+void BaseClient::setLastError(std::string code, std::string message) {
+    lastErrorCode_ = std::move(code);
+    lastErrorMessage_ = std::move(message);
+}
+
+void BaseClient::clearLastError() {
+    lastErrorCode_.clear();
+    lastErrorMessage_.clear();
 }
 
 } // namespace eliza_api_client

--- a/cpp/packages/applications/eliza/packages/api-client/src/lib/base-client.hpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/lib/base-client.hpp
@@ -1,32 +1,96 @@
 #ifndef ELIZAOS_CPP_PACKAGES_APPLICATIONS_ELIZA_PACKAGES_API_CLIENT_SRC_LIB_BASE_CLIENT_HPP_
 #define ELIZAOS_CPP_PACKAGES_APPLICATIONS_ELIZA_PACKAGES_API_CLIENT_SRC_LIB_BASE_CLIENT_HPP_
 
-#include <string>
-#include <vector>
 #include <map>
 #include <memory>
-#include <functional>
 #include <optional>
+#include <string>
+#include <vector>
+
 #include <nlohmann/json.hpp>
 
 namespace elizaos {
 namespace eliza_api_client {
 
+struct HttpRequest {
+    std::string method;
+    std::string url;
+    std::string path;
+    std::map<std::string, std::string> headers;
+    nlohmann::json query = nlohmann::json::object();
+    nlohmann::json body = nlohmann::json::object();
+};
+
+struct HttpResponse {
+    int statusCode = 0;
+    std::map<std::string, std::string> headers;
+    std::string body;
+    nlohmann::json jsonBody = nlohmann::json::object();
+};
+
+struct ApiResult {
+    bool ok = false;
+    HttpResponse response;
+    std::string errorCode;
+    std::string errorMessage;
+
+    static ApiResult success(HttpResponse response);
+    static ApiResult failure(std::string code, std::string message, HttpResponse response = {});
+};
+
+class IHttpTransport {
+public:
+    virtual ~IHttpTransport() = default;
+    virtual ApiResult send(const HttpRequest& request) = 0;
+    virtual bool isReady() const { return true; }
+    virtual std::string getName() const { return "http_transport"; }
+};
+
 class BaseClient {
 public:
     BaseClient() = default;
+    explicit BaseClient(std::shared_ptr<IHttpTransport> transport);
     ~BaseClient() = default;
 
     bool initialize(const nlohmann::json& config = {});
     void shutdown();
+
+    void setTransport(std::shared_ptr<IHttpTransport> transport);
+    std::shared_ptr<IHttpTransport> getTransport() const { return transport_; }
+
+    ApiResult request(const std::string& method,
+                      const std::string& path,
+                      const nlohmann::json& body = nlohmann::json::object(),
+                      const std::map<std::string, std::string>& headers = {}) const;
+
+    std::string buildUrl(const std::string& path) const;
     nlohmann::json getStatus() const;
     std::string getName() const { return "base_client"; }
     bool isInitialized() const { return initialized_; }
+    bool isConfigured() const { return configured_; }
+    bool isTransportReady() const;
     const nlohmann::json& getConfig() const { return config_; }
+    const std::string& getBaseUrl() const { return baseUrl_; }
+    const std::string& getLastErrorCode() const { return lastErrorCode_; }
+    const std::string& getLastErrorMessage() const { return lastErrorMessage_; }
 
 private:
-    nlohmann::json config_;
+    static std::string trim(const std::string& value);
+    static std::string normalizeBaseUrl(const std::string& value);
+    static bool isHttpUrl(const std::string& value);
+    bool validateConfig(const nlohmann::json& config);
+    void setLastError(std::string code, std::string message);
+    void clearLastError();
+
+    nlohmann::json config_ = nlohmann::json::object();
     bool initialized_ = false;
+    bool configured_ = false;
+    std::string baseUrl_;
+    int timeoutMs_ = 30000;
+    int maxRetries_ = 0;
+    std::string lastErrorCode_;
+    std::string lastErrorMessage_;
+    std::shared_ptr<IHttpTransport> transport_;
 };
 
 } // namespace eliza_api_client

--- a/cpp/packages/applications/eliza/packages/api-client/src/lib/curl-transport.cpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/lib/curl-transport.cpp
@@ -1,0 +1,484 @@
+#include "curl-transport.hpp"
+
+#include <curl/curl.h>
+#include <sstream>
+#include <algorithm>
+#include <cctype>
+#include <thread>
+
+namespace elizaos {
+namespace eliza_api_client {
+
+// Write callback for curl to capture response body
+size_t CurlTransport::writeCallback(void* contents, size_t size, size_t nmemb, void* userp) {
+    size_t realSize = size * nmemb;
+    auto* response = static_cast<std::string*>(userp);
+    response->append(static_cast<char*>(contents), realSize);
+    return realSize;
+}
+
+// Header callback for curl to capture response headers
+size_t CurlTransport::headerCallback(char* buffer, size_t size, size_t nitems, void* userdata) {
+    size_t totalSize = size * nitems;
+    auto* headers = static_cast<std::map<std::string, std::string>*>(userdata);
+    
+    std::string headerLine(buffer, totalSize);
+    // Remove trailing CRLF
+    while (!headerLine.empty() && (headerLine.back() == '\r' || headerLine.back() == '\n')) {
+        headerLine.pop_back();
+    }
+    
+    // Skip empty lines and HTTP status line
+    if (headerLine.empty() || headerLine.find("HTTP/") == 0) {
+        return totalSize;
+    }
+    
+    // Parse "Key: Value" format
+    auto colonPos = headerLine.find(':');
+    if (colonPos != std::string::npos) {
+        std::string key = headerLine.substr(0, colonPos);
+        std::string value = headerLine.substr(colonPos + 1);
+        
+        // Trim whitespace from key and value
+        while (!key.empty() && std::isspace(static_cast<unsigned char>(key.back()))) {
+            key.pop_back();
+        }
+        while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front()))) {
+            value.erase(value.begin());
+        }
+        
+        // Convert key to lowercase for case-insensitive lookup
+        std::transform(key.begin(), key.end(), key.begin(), 
+                       [](unsigned char c) { return std::tolower(c); });
+        
+        (*headers)[key] = value;
+    }
+    
+    return totalSize;
+}
+
+CurlTransport::CurlTransport() {
+    initializeCurl();
+}
+
+CurlTransport::CurlTransport(const CurlTransportConfig& config)
+    : config_(config) {
+    initializeCurl();
+}
+
+CurlTransport::~CurlTransport() {
+    cleanupCurl();
+}
+
+CurlTransport::CurlTransport(CurlTransport&& other) noexcept
+    : config_(std::move(other.config_))
+    , curlHandle_(other.curlHandle_)
+    , initialized_(other.initialized_)
+    , totalRequests_(other.totalRequests_)
+    , successfulRequests_(other.successfulRequests_)
+    , failedRequests_(other.failedRequests_)
+    , retriedRequests_(other.retriedRequests_)
+    , totalRequestTime_(other.totalRequestTime_)
+    , lastRequestTime_(other.lastRequestTime_) {
+    other.curlHandle_ = nullptr;
+    other.initialized_ = false;
+}
+
+CurlTransport& CurlTransport::operator=(CurlTransport&& other) noexcept {
+    if (this != &other) {
+        cleanupCurl();
+        config_ = std::move(other.config_);
+        curlHandle_ = other.curlHandle_;
+        initialized_ = other.initialized_;
+        totalRequests_ = other.totalRequests_;
+        successfulRequests_ = other.successfulRequests_;
+        failedRequests_ = other.failedRequests_;
+        retriedRequests_ = other.retriedRequests_;
+        totalRequestTime_ = other.totalRequestTime_;
+        lastRequestTime_ = other.lastRequestTime_;
+        other.curlHandle_ = nullptr;
+        other.initialized_ = false;
+    }
+    return *this;
+}
+
+bool CurlTransport::initializeCurl() {
+    if (initialized_) {
+        return true;
+    }
+
+    CURL* handle = curl_easy_init();
+    if (!handle) {
+        return false;
+    }
+
+    curlHandle_ = handle;
+    initialized_ = true;
+    return true;
+}
+
+void CurlTransport::cleanupCurl() {
+    if (curlHandle_) {
+        curl_easy_cleanup(static_cast<CURL*>(curlHandle_));
+        curlHandle_ = nullptr;
+    }
+    initialized_ = false;
+}
+
+bool CurlTransport::isReady() const {
+    return initialized_ && curlHandle_ != nullptr;
+}
+
+std::string CurlTransport::buildQueryString(const nlohmann::json& query) const {
+    if (!query.is_object() || query.empty()) {
+        return "";
+    }
+
+    std::ostringstream oss;
+    bool first = true;
+    
+    for (auto it = query.begin(); it != query.end(); ++it) {
+        if (!first) {
+            oss << "&";
+        }
+        first = false;
+        
+        // URL-encode the key
+        char* encodedKey = curl_easy_escape(static_cast<CURL*>(curlHandle_), 
+                                            it.key().c_str(), 
+                                            static_cast<int>(it.key().length()));
+        if (encodedKey) {
+            oss << encodedKey;
+            curl_free(encodedKey);
+        } else {
+            oss << it.key();
+        }
+        
+        oss << "=";
+        
+        // Convert value to string and URL-encode
+        std::string valueStr;
+        if (it.value().is_string()) {
+            valueStr = it.value().get<std::string>();
+        } else {
+            valueStr = it.value().dump();
+        }
+        
+        char* encodedValue = curl_easy_escape(static_cast<CURL*>(curlHandle_),
+                                              valueStr.c_str(),
+                                              static_cast<int>(valueStr.length()));
+        if (encodedValue) {
+            oss << encodedValue;
+            curl_free(encodedValue);
+        } else {
+            oss << valueStr;
+        }
+    }
+
+    return oss.str();
+}
+
+bool CurlTransport::shouldRetry(long httpCode, int attemptNumber) const {
+    if (attemptNumber >= config_.maxRetries) {
+        return false;
+    }
+    
+    // Retry on server errors and specific client errors
+    if (httpCode >= 500 && httpCode < 600) {
+        return true;  // Server errors
+    }
+    if (httpCode == 429) {
+        return true;  // Rate limited
+    }
+    if (httpCode == 408) {
+        return true;  // Request timeout
+    }
+    
+    return false;
+}
+
+ApiResult CurlTransport::performRequest(const HttpRequest& request) {
+    auto startTime = std::chrono::steady_clock::now();
+    
+    if (!isReady()) {
+        ++failedRequests_;
+        return ApiResult::failure("transport_not_initialized", 
+                                  "CurlTransport is not initialized.");
+    }
+
+    CURL* curl = static_cast<CURL*>(curlHandle_);
+    
+    // Reset curl handle for new request
+    curl_easy_reset(curl);
+
+    // Build URL with query string
+    std::string fullUrl = request.url;
+    std::string queryString = buildQueryString(request.query);
+    if (!queryString.empty()) {
+        fullUrl += (fullUrl.find('?') == std::string::npos ? "?" : "&") + queryString;
+    }
+
+    // Set URL
+    curl_easy_setopt(curl, CURLOPT_URL, fullUrl.c_str());
+
+    // Set method
+    std::string methodUpper = request.method;
+    std::transform(methodUpper.begin(), methodUpper.end(), methodUpper.begin(),
+                   [](unsigned char c) { return std::toupper(c); });
+    
+    if (methodUpper == "GET") {
+        curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    } else if (methodUpper == "POST") {
+        curl_easy_setopt(curl, CURLOPT_POST, 1L);
+    } else if (methodUpper == "PUT") {
+        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
+    } else if (methodUpper == "DELETE") {
+        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+    } else if (methodUpper == "PATCH") {
+        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PATCH");
+    } else if (methodUpper == "HEAD") {
+        curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
+    } else {
+        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, methodUpper.c_str());
+    }
+
+    // Set request body
+    std::string bodyStr;
+    if (!request.body.is_null() && !request.body.empty()) {
+        bodyStr = request.body.dump();
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, bodyStr.c_str());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(bodyStr.length()));
+    }
+
+    // Set headers
+    struct curl_slist* headers = nullptr;
+    
+    // Add default headers
+    for (const auto& [key, value] : config_.defaultHeaders) {
+        std::string header = key + ": " + value;
+        headers = curl_slist_append(headers, header.c_str());
+    }
+    
+    // Add request-specific headers
+    bool hasContentType = false;
+    for (const auto& [key, value] : request.headers) {
+        std::string keyLower = key;
+        std::transform(keyLower.begin(), keyLower.end(), keyLower.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        if (keyLower == "content-type") {
+            hasContentType = true;
+        }
+        std::string header = key + ": " + value;
+        headers = curl_slist_append(headers, header.c_str());
+    }
+    
+    // Add default Content-Type for requests with body
+    if (!hasContentType && !bodyStr.empty()) {
+        headers = curl_slist_append(headers, "Content-Type: application/json");
+    }
+    
+    // Add Accept header if not present
+    headers = curl_slist_append(headers, "Accept: application/json");
+    
+    if (headers) {
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    }
+
+    // Set User-Agent
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, config_.userAgent.c_str());
+
+    // Set timeouts
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(config_.timeoutMs));
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, static_cast<long>(config_.connectTimeoutMs));
+
+    // Set SSL options
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, config_.verifySSL ? 1L : 0L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, config_.verifySSL ? 2L : 0L);
+
+    // Set redirect options
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, config_.followRedirects ? 1L : 0L);
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, static_cast<long>(config_.maxRedirects));
+
+    // Set up response capture
+    std::string responseBody;
+    std::map<std::string, std::string> responseHeaders;
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &responseBody);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, headerCallback);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &responseHeaders);
+
+    // Perform request with retry logic
+    CURLcode res = CURLE_OK;
+    long httpCode = 0;
+    int attempts = 0;
+    
+    do {
+        if (attempts > 0) {
+            ++retriedRequests_;
+            // Wait before retry
+            std::this_thread::sleep_for(std::chrono::milliseconds(config_.retryDelayMs * attempts));
+            responseBody.clear();
+            responseHeaders.clear();
+        }
+        
+        res = curl_easy_perform(curl);
+        
+        if (res == CURLE_OK) {
+            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
+        }
+        
+        ++attempts;
+    } while (res == CURLE_OK && shouldRetry(httpCode, attempts));
+
+    // Clean up headers
+    if (headers) {
+        curl_slist_free_all(headers);
+    }
+
+    // Calculate request time
+    auto endTime = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
+    totalRequestTime_ += duration;
+    lastRequestTime_ = std::chrono::system_clock::now();
+    ++totalRequests_;
+
+    // Handle curl errors
+    if (res != CURLE_OK) {
+        ++failedRequests_;
+        std::string errorMsg = curl_easy_strerror(res);
+        return ApiResult::failure("curl_error", errorMsg);
+    }
+
+    // Parse and return response
+    return parseResponse(responseBody, responseHeaders, httpCode);
+}
+
+ApiResult CurlTransport::parseResponse(const std::string& responseBody,
+                                       const std::map<std::string, std::string>& responseHeaders,
+                                       long httpCode) const {
+    HttpResponse response;
+    response.statusCode = static_cast<int>(httpCode);
+    response.headers = responseHeaders;
+    response.body = responseBody;
+
+    // Try to parse JSON body
+    auto contentTypeIt = responseHeaders.find("content-type");
+    bool isJson = contentTypeIt != responseHeaders.end() && 
+                  contentTypeIt->second.find("application/json") != std::string::npos;
+    
+    if (isJson && !responseBody.empty()) {
+        try {
+            response.jsonBody = nlohmann::json::parse(responseBody);
+        } catch (const nlohmann::json::parse_error&) {
+            // Not valid JSON, leave jsonBody as empty object
+        }
+    }
+
+    // Determine success based on HTTP status code
+    if (httpCode >= 200 && httpCode < 300) {
+        ++successfulRequests_;
+        return ApiResult::success(std::move(response));
+    } else {
+        ++failedRequests_;
+        std::string errorCode = "http_" + std::to_string(httpCode);
+        std::string errorMessage = "HTTP request failed with status " + std::to_string(httpCode);
+        
+        // Try to extract error message from response body
+        if (!response.jsonBody.is_null() && response.jsonBody.contains("error")) {
+            if (response.jsonBody["error"].is_string()) {
+                errorMessage = response.jsonBody["error"].get<std::string>();
+            } else if (response.jsonBody["error"].is_object() && 
+                       response.jsonBody["error"].contains("message")) {
+                errorMessage = response.jsonBody["error"]["message"].get<std::string>();
+            }
+        } else if (!response.jsonBody.is_null() && response.jsonBody.contains("message")) {
+            errorMessage = response.jsonBody["message"].get<std::string>();
+        }
+        
+        return ApiResult::failure(errorCode, errorMessage, std::move(response));
+    }
+}
+
+ApiResult CurlTransport::send(const HttpRequest& request) {
+    return performRequest(request);
+}
+
+nlohmann::json CurlTransport::getDiagnostics() const {
+    nlohmann::json diagnostics;
+    diagnostics["name"] = getName();
+    diagnostics["initialized"] = initialized_;
+    diagnostics["curlHandleValid"] = curlHandle_ != nullptr;
+    
+    if (curlHandle_) {
+        curl_version_info_data* info = curl_version_info(CURLVERSION_NOW);
+        if (info) {
+            diagnostics["curlVersion"] = info->version;
+            diagnostics["sslVersion"] = info->ssl_version ? info->ssl_version : "none";
+            diagnostics["protocols"] = nlohmann::json::array();
+            if (info->protocols) {
+                for (int i = 0; info->protocols[i]; ++i) {
+                    diagnostics["protocols"].push_back(info->protocols[i]);
+                }
+            }
+        }
+    }
+    
+    diagnostics["config"] = nlohmann::json{
+        {"timeoutMs", config_.timeoutMs},
+        {"connectTimeoutMs", config_.connectTimeoutMs},
+        {"maxRetries", config_.maxRetries},
+        {"retryDelayMs", config_.retryDelayMs},
+        {"verifySSL", config_.verifySSL},
+        {"followRedirects", config_.followRedirects},
+        {"maxRedirects", config_.maxRedirects},
+        {"userAgent", config_.userAgent}
+    };
+    
+    return diagnostics;
+}
+
+nlohmann::json CurlTransport::getStats() const {
+    nlohmann::json stats;
+    stats["totalRequests"] = totalRequests_;
+    stats["successfulRequests"] = successfulRequests_;
+    stats["failedRequests"] = failedRequests_;
+    stats["retriedRequests"] = retriedRequests_;
+    stats["totalRequestTimeMs"] = totalRequestTime_.count();
+    
+    if (totalRequests_ > 0) {
+        stats["averageRequestTimeMs"] = totalRequestTime_.count() / totalRequests_;
+        stats["successRate"] = static_cast<double>(successfulRequests_) / totalRequests_;
+    } else {
+        stats["averageRequestTimeMs"] = 0;
+        stats["successRate"] = 0.0;
+    }
+    
+    if (lastRequestTime_ != std::chrono::system_clock::time_point{}) {
+        auto now = std::chrono::system_clock::now();
+        auto sinceLastRequest = std::chrono::duration_cast<std::chrono::seconds>(
+            now - lastRequestTime_).count();
+        stats["secondsSinceLastRequest"] = sinceLastRequest;
+    }
+    
+    return stats;
+}
+
+void CurlTransport::resetStats() {
+    totalRequests_ = 0;
+    successfulRequests_ = 0;
+    failedRequests_ = 0;
+    retriedRequests_ = 0;
+    totalRequestTime_ = std::chrono::milliseconds{0};
+    lastRequestTime_ = std::chrono::system_clock::time_point{};
+}
+
+std::shared_ptr<IHttpTransport> createCurlTransport() {
+    return std::make_shared<CurlTransport>();
+}
+
+std::shared_ptr<IHttpTransport> createCurlTransport(const CurlTransportConfig& config) {
+    return std::make_shared<CurlTransport>(config);
+}
+
+} // namespace eliza_api_client
+} // namespace elizaos

--- a/cpp/packages/applications/eliza/packages/api-client/src/lib/curl-transport.hpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/lib/curl-transport.hpp
@@ -1,0 +1,132 @@
+#ifndef ELIZAOS_CPP_PACKAGES_APPLICATIONS_ELIZA_PACKAGES_API_CLIENT_SRC_LIB_CURL_TRANSPORT_HPP_
+#define ELIZAOS_CPP_PACKAGES_APPLICATIONS_ELIZA_PACKAGES_API_CLIENT_SRC_LIB_CURL_TRANSPORT_HPP_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <chrono>
+
+#include <nlohmann/json.hpp>
+
+#include "base-client.hpp"
+
+namespace elizaos {
+namespace eliza_api_client {
+
+/**
+ * Configuration options for the curl-based HTTP transport.
+ */
+struct CurlTransportConfig {
+    int timeoutMs = 30000;              ///< Request timeout in milliseconds
+    int connectTimeoutMs = 10000;       ///< Connection timeout in milliseconds
+    int maxRetries = 3;                 ///< Maximum retry attempts
+    int retryDelayMs = 1000;            ///< Delay between retries in milliseconds
+    bool verifySSL = true;              ///< Whether to verify SSL certificates
+    bool followRedirects = true;        ///< Whether to follow HTTP redirects
+    int maxRedirects = 10;              ///< Maximum number of redirects to follow
+    std::string userAgent = "ElizaOS-CPP/1.0";  ///< User agent string
+    std::map<std::string, std::string> defaultHeaders;  ///< Default headers for all requests
+};
+
+/**
+ * Production HTTP transport implementation using libcurl.
+ * 
+ * This transport provides:
+ * - Full HTTP/HTTPS support
+ * - Connection pooling via curl handle reuse
+ * - Configurable timeouts and retry logic
+ * - SSL/TLS verification
+ * - Automatic redirect following
+ * - JSON request/response handling
+ * - Thread-safe operation (one transport per thread recommended)
+ */
+class CurlTransport : public IHttpTransport {
+public:
+    CurlTransport();
+    explicit CurlTransport(const CurlTransportConfig& config);
+    ~CurlTransport() override;
+
+    // Non-copyable, but movable
+    CurlTransport(const CurlTransport&) = delete;
+    CurlTransport& operator=(const CurlTransport&) = delete;
+    CurlTransport(CurlTransport&& other) noexcept;
+    CurlTransport& operator=(CurlTransport&& other) noexcept;
+
+    /**
+     * Send an HTTP request and receive the response.
+     * @param request The HTTP request to send.
+     * @return ApiResult containing the response or error information.
+     */
+    ApiResult send(const HttpRequest& request) override;
+
+    /**
+     * Check if the transport is ready to send requests.
+     * @return true if initialized successfully, false otherwise.
+     */
+    bool isReady() const override;
+
+    /**
+     * Get the transport name.
+     * @return "curl_transport"
+     */
+    std::string getName() const override { return "curl_transport"; }
+
+    /**
+     * Get the current configuration.
+     */
+    const CurlTransportConfig& getConfig() const { return config_; }
+
+    /**
+     * Get diagnostic information about the transport.
+     */
+    nlohmann::json getDiagnostics() const;
+
+    /**
+     * Get statistics about requests made by this transport.
+     */
+    nlohmann::json getStats() const;
+
+    /**
+     * Reset statistics counters.
+     */
+    void resetStats();
+
+private:
+    bool initializeCurl();
+    void cleanupCurl();
+    std::string buildQueryString(const nlohmann::json& query) const;
+    static size_t writeCallback(void* contents, size_t size, size_t nmemb, void* userp);
+    static size_t headerCallback(char* buffer, size_t size, size_t nitems, void* userdata);
+    ApiResult performRequest(const HttpRequest& request);
+    ApiResult parseResponse(const std::string& responseBody, 
+                           const std::map<std::string, std::string>& responseHeaders,
+                           long httpCode) const;
+    bool shouldRetry(long httpCode, int attemptNumber) const;
+
+    CurlTransportConfig config_;
+    void* curlHandle_ = nullptr;  // CURL* but using void* to avoid including curl.h
+    bool initialized_ = false;
+
+    // Statistics
+    mutable int totalRequests_ = 0;
+    mutable int successfulRequests_ = 0;
+    mutable int failedRequests_ = 0;
+    mutable int retriedRequests_ = 0;
+    mutable std::chrono::milliseconds totalRequestTime_{0};
+    mutable std::chrono::system_clock::time_point lastRequestTime_;
+};
+
+/**
+ * Factory function to create a CurlTransport with default configuration.
+ */
+std::shared_ptr<IHttpTransport> createCurlTransport();
+
+/**
+ * Factory function to create a CurlTransport with custom configuration.
+ */
+std::shared_ptr<IHttpTransport> createCurlTransport(const CurlTransportConfig& config);
+
+} // namespace eliza_api_client
+} // namespace elizaos
+
+#endif // ELIZAOS_CPP_PACKAGES_APPLICATIONS_ELIZA_PACKAGES_API_CLIENT_SRC_LIB_CURL_TRANSPORT_HPP_

--- a/cpp/packages/applications/eliza/packages/api-client/src/services/agents.cpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/services/agents.cpp
@@ -1,25 +1,199 @@
 #include "agents.hpp"
 
+#include <utility>
+
 namespace elizaos {
 namespace eliza_api_client {
 
+namespace {
+std::string stringValueOrDefault(const nlohmann::json& config,
+                                 const std::string& camelKey,
+                                 const std::string& snakeKey,
+                                 const std::string& defaultValue) {
+    const auto camelIt = config.find(camelKey);
+    if (camelIt != config.end() && camelIt->is_string() && !camelIt->get<std::string>().empty()) {
+        return camelIt->get<std::string>();
+    }
+
+    const auto snakeIt = config.find(snakeKey);
+    if (snakeIt != config.end() && snakeIt->is_string() && !snakeIt->get<std::string>().empty()) {
+        return snakeIt->get<std::string>();
+    }
+
+    return defaultValue;
+}
+} // namespace
+
+Agents::Agents(std::shared_ptr<BaseClient> client)
+    : client_(std::move(client)) {}
+
 bool Agents::initialize(const nlohmann::json& config) {
-    if (initialized_) return true;
+    if (initialized_) {
+        return true;
+    }
+
+    if (!config.is_object()) {
+        setLastError("invalid_config", "Agents service configuration must be a JSON object.");
+        return false;
+    }
+
     config_ = config;
+    basePath_ = stringValueOrDefault(config_, "basePath", "base_path", "/api/agents");
+    config_["basePath"] = basePath_;
+
+    if (!client_) {
+        client_ = std::make_shared<BaseClient>();
+    }
+
+    if (!client_->isInitialized()) {
+        if (!client_->initialize(config_)) {
+            setLastError(client_->getLastErrorCode().empty() ? "client_initialization_failed" : client_->getLastErrorCode(),
+                         client_->getLastErrorMessage().empty() ? "Agents service could not initialize its BaseClient." : client_->getLastErrorMessage());
+            initialized_ = false;
+            return false;
+        }
+    }
+
     initialized_ = true;
+    clearLastError();
     return true;
 }
 
 void Agents::shutdown() {
     initialized_ = false;
-    config_ = {};
+    config_ = nlohmann::json::object();
+    basePath_ = "/api/agents";
+    clearLastError();
+}
+
+void Agents::setClient(std::shared_ptr<BaseClient> client) {
+    client_ = std::move(client);
+}
+
+ApiResult Agents::list() const {
+    if (!initialized_) {
+        return ApiResult::failure("agents_not_initialized", "Agents service must be initialized before listing agents.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "Agents service has no BaseClient configured.");
+    }
+    return client_->request("GET", basePath_);
+}
+
+ApiResult Agents::get(const std::string& agentId) const {
+    if (!initialized_) {
+        return ApiResult::failure("agents_not_initialized", "Agents service must be initialized before getting agent details.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "Agents service has no BaseClient configured.");
+    }
+    if (agentId.empty()) {
+        return ApiResult::failure("invalid_agent_id", "Agent ID must not be empty.");
+    }
+    return client_->request("GET", basePath_ + "/" + agentId);
+}
+
+ApiResult Agents::create(const nlohmann::json& agentConfig) const {
+    if (!initialized_) {
+        return ApiResult::failure("agents_not_initialized", "Agents service must be initialized before creating agents.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "Agents service has no BaseClient configured.");
+    }
+    if (!agentConfig.is_object()) {
+        return ApiResult::failure("invalid_config", "Agent configuration must be a JSON object.");
+    }
+    return client_->request("POST", basePath_, agentConfig);
+}
+
+ApiResult Agents::update(const std::string& agentId, const nlohmann::json& agentConfig) const {
+    if (!initialized_) {
+        return ApiResult::failure("agents_not_initialized", "Agents service must be initialized before updating agents.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "Agents service has no BaseClient configured.");
+    }
+    if (agentId.empty()) {
+        return ApiResult::failure("invalid_agent_id", "Agent ID must not be empty.");
+    }
+    if (!agentConfig.is_object()) {
+        return ApiResult::failure("invalid_config", "Agent configuration must be a JSON object.");
+    }
+    return client_->request("PUT", basePath_ + "/" + agentId, agentConfig);
+}
+
+ApiResult Agents::remove(const std::string& agentId) const {
+    if (!initialized_) {
+        return ApiResult::failure("agents_not_initialized", "Agents service must be initialized before removing agents.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "Agents service has no BaseClient configured.");
+    }
+    if (agentId.empty()) {
+        return ApiResult::failure("invalid_agent_id", "Agent ID must not be empty.");
+    }
+    return client_->request("DELETE", basePath_ + "/" + agentId);
+}
+
+ApiResult Agents::getAgentStatus(const std::string& agentId) const {
+    if (!initialized_) {
+        return ApiResult::failure("agents_not_initialized", "Agents service must be initialized before getting agent status.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "Agents service has no BaseClient configured.");
+    }
+    if (agentId.empty()) {
+        return ApiResult::failure("invalid_agent_id", "Agent ID must not be empty.");
+    }
+    return client_->request("GET", basePath_ + "/" + agentId + "/status");
+}
+
+ApiResult Agents::start(const std::string& agentId) const {
+    if (!initialized_) {
+        return ApiResult::failure("agents_not_initialized", "Agents service must be initialized before starting agents.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "Agents service has no BaseClient configured.");
+    }
+    if (agentId.empty()) {
+        return ApiResult::failure("invalid_agent_id", "Agent ID must not be empty.");
+    }
+    return client_->request("POST", basePath_ + "/" + agentId + "/start");
+}
+
+ApiResult Agents::stop(const std::string& agentId) const {
+    if (!initialized_) {
+        return ApiResult::failure("agents_not_initialized", "Agents service must be initialized before stopping agents.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "Agents service has no BaseClient configured.");
+    }
+    if (agentId.empty()) {
+        return ApiResult::failure("invalid_agent_id", "Agent ID must not be empty.");
+    }
+    return client_->request("POST", basePath_ + "/" + agentId + "/stop");
 }
 
 nlohmann::json Agents::getStatus() const {
     nlohmann::json status;
     status["name"] = getName();
     status["initialized"] = initialized_;
+    status["basePath"] = basePath_;
+    status["clientConfigured"] = static_cast<bool>(client_);
+    status["client"] = client_ ? client_->getStatus() : nlohmann::json::object();
+    status["lastErrorCode"] = lastErrorCode_;
+    status["lastErrorMessage"] = lastErrorMessage_;
     return status;
+}
+
+void Agents::setLastError(std::string code, std::string message) {
+    lastErrorCode_ = std::move(code);
+    lastErrorMessage_ = std::move(message);
+}
+
+void Agents::clearLastError() {
+    lastErrorCode_.clear();
+    lastErrorMessage_.clear();
 }
 
 } // namespace eliza_api_client

--- a/cpp/packages/applications/eliza/packages/api-client/src/services/agents.hpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/services/agents.hpp
@@ -9,24 +9,99 @@
 #include <optional>
 #include <nlohmann/json.hpp>
 
+#include "../lib/base-client.hpp"
+
 namespace elizaos {
 namespace eliza_api_client {
 
+/**
+ * Agents service for managing ElizaOS agents.
+ * 
+ * This service provides endpoints for:
+ * - Listing all agents
+ * - Getting agent details
+ * - Creating new agents
+ * - Updating agent configuration
+ * - Deleting agents
+ * - Agent status and health
+ */
 class Agents {
 public:
     Agents() = default;
+    explicit Agents(std::shared_ptr<BaseClient> client);
     ~Agents() = default;
 
     bool initialize(const nlohmann::json& config = {});
     void shutdown();
+
+    void setClient(std::shared_ptr<BaseClient> client);
+    std::shared_ptr<BaseClient> getClient() const { return client_; }
+
+    /**
+     * Get list of all agents.
+     */
+    ApiResult list() const;
+
+    /**
+     * Get details for a specific agent.
+     * @param agentId The agent identifier.
+     */
+    ApiResult get(const std::string& agentId) const;
+
+    /**
+     * Create a new agent.
+     * @param agentConfig The agent configuration.
+     */
+    ApiResult create(const nlohmann::json& agentConfig) const;
+
+    /**
+     * Update an existing agent.
+     * @param agentId The agent identifier.
+     * @param agentConfig The updated agent configuration.
+     */
+    ApiResult update(const std::string& agentId, const nlohmann::json& agentConfig) const;
+
+    /**
+     * Delete an agent.
+     * @param agentId The agent identifier.
+     */
+    ApiResult remove(const std::string& agentId) const;
+
+    /**
+     * Get the status of a specific agent.
+     * @param agentId The agent identifier.
+     */
+    ApiResult getAgentStatus(const std::string& agentId) const;
+
+    /**
+     * Start an agent.
+     * @param agentId The agent identifier.
+     */
+    ApiResult start(const std::string& agentId) const;
+
+    /**
+     * Stop an agent.
+     * @param agentId The agent identifier.
+     */
+    ApiResult stop(const std::string& agentId) const;
+
     nlohmann::json getStatus() const;
     std::string getName() const { return "agents"; }
     bool isInitialized() const { return initialized_; }
-    const nlohmann::json& getConfig() const { return config_; }
+    const nlohmann::json& getServiceConfig() const { return config_; }
+    const std::string& getLastErrorCode() const { return lastErrorCode_; }
+    const std::string& getLastErrorMessage() const { return lastErrorMessage_; }
 
 private:
-    nlohmann::json config_;
+    void setLastError(std::string code, std::string message);
+    void clearLastError();
+
+    nlohmann::json config_ = nlohmann::json::object();
     bool initialized_ = false;
+    std::string basePath_ = "/api/agents";
+    std::string lastErrorCode_;
+    std::string lastErrorMessage_;
+    std::shared_ptr<BaseClient> client_;
 };
 
 } // namespace eliza_api_client

--- a/cpp/packages/applications/eliza/packages/api-client/src/services/server.cpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/services/server.cpp
@@ -1,25 +1,119 @@
 #include "server.hpp"
 
+#include <utility>
+
 namespace elizaos {
 namespace eliza_api_client {
 
+namespace {
+std::string stringValueOrDefault(const nlohmann::json& config,
+                                 const std::string& camelKey,
+                                 const std::string& snakeKey,
+                                 const std::string& defaultValue) {
+    const auto camelIt = config.find(camelKey);
+    if (camelIt != config.end() && camelIt->is_string() && !camelIt->get<std::string>().empty()) {
+        return camelIt->get<std::string>();
+    }
+
+    const auto snakeIt = config.find(snakeKey);
+    if (snakeIt != config.end() && snakeIt->is_string() && !snakeIt->get<std::string>().empty()) {
+        return snakeIt->get<std::string>();
+    }
+
+    return defaultValue;
+}
+} // namespace
+
+Server::Server(std::shared_ptr<BaseClient> client)
+    : client_(std::move(client)) {}
+
 bool Server::initialize(const nlohmann::json& config) {
-    if (initialized_) return true;
+    if (initialized_) {
+        return true;
+    }
+
+    if (!config.is_object()) {
+        setLastError("invalid_config", "Server service configuration must be a JSON object.");
+        return false;
+    }
+
     config_ = config;
+    healthPath_ = stringValueOrDefault(config_, "healthPath", "health_path", "/api/server/health");
+    statusPath_ = stringValueOrDefault(config_, "statusPath", "status_path", "/api/server/status");
+    config_["healthPath"] = healthPath_;
+    config_["statusPath"] = statusPath_;
+
+    if (!client_) {
+        client_ = std::make_shared<BaseClient>();
+    }
+
+    if (!client_->isInitialized()) {
+        if (!client_->initialize(config_)) {
+            setLastError(client_->getLastErrorCode().empty() ? "client_initialization_failed" : client_->getLastErrorCode(),
+                         client_->getLastErrorMessage().empty() ? "Server service could not initialize its BaseClient." : client_->getLastErrorMessage());
+            initialized_ = false;
+            return false;
+        }
+    }
+
     initialized_ = true;
+    clearLastError();
     return true;
 }
 
 void Server::shutdown() {
     initialized_ = false;
-    config_ = {};
+    config_ = nlohmann::json::object();
+    healthPath_ = "/api/server/health";
+    statusPath_ = "/api/server/status";
+    clearLastError();
+}
+
+void Server::setClient(std::shared_ptr<BaseClient> client) {
+    client_ = std::move(client);
+}
+
+ApiResult Server::getHealth() const {
+    if (!initialized_) {
+        return ApiResult::failure("server_not_initialized", "Server service must be initialized before health can be requested.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "Server service has no BaseClient configured.");
+    }
+    return client_->request("GET", healthPath_);
+}
+
+ApiResult Server::getServerStatus() const {
+    if (!initialized_) {
+        return ApiResult::failure("server_not_initialized", "Server service must be initialized before server status can be requested.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "Server service has no BaseClient configured.");
+    }
+    return client_->request("GET", statusPath_);
 }
 
 nlohmann::json Server::getStatus() const {
     nlohmann::json status;
     status["name"] = getName();
     status["initialized"] = initialized_;
+    status["healthPath"] = healthPath_;
+    status["statusPath"] = statusPath_;
+    status["clientConfigured"] = static_cast<bool>(client_);
+    status["client"] = client_ ? client_->getStatus() : nlohmann::json::object();
+    status["lastErrorCode"] = lastErrorCode_;
+    status["lastErrorMessage"] = lastErrorMessage_;
     return status;
+}
+
+void Server::setLastError(std::string code, std::string message) {
+    lastErrorCode_ = std::move(code);
+    lastErrorMessage_ = std::move(message);
+}
+
+void Server::clearLastError() {
+    lastErrorCode_.clear();
+    lastErrorMessage_.clear();
 }
 
 } // namespace eliza_api_client

--- a/cpp/packages/applications/eliza/packages/api-client/src/services/server.hpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/services/server.hpp
@@ -1,13 +1,12 @@
 #ifndef ELIZAOS_CPP_PACKAGES_APPLICATIONS_ELIZA_PACKAGES_API_CLIENT_SRC_SERVICES_SERVER_HPP_
 #define ELIZAOS_CPP_PACKAGES_APPLICATIONS_ELIZA_PACKAGES_API_CLIENT_SRC_SERVICES_SERVER_HPP_
 
-#include <string>
-#include <vector>
-#include <map>
 #include <memory>
-#include <functional>
-#include <optional>
+#include <string>
+
 #include <nlohmann/json.hpp>
+
+#include "../lib/base-client.hpp"
 
 namespace elizaos {
 namespace eliza_api_client {
@@ -15,18 +14,36 @@ namespace eliza_api_client {
 class Server {
 public:
     Server() = default;
+    explicit Server(std::shared_ptr<BaseClient> client);
     ~Server() = default;
 
     bool initialize(const nlohmann::json& config = {});
     void shutdown();
+
+    void setClient(std::shared_ptr<BaseClient> client);
+    std::shared_ptr<BaseClient> getClient() const { return client_; }
+
+    ApiResult getHealth() const;
+    ApiResult getServerStatus() const;
+
     nlohmann::json getStatus() const;
     std::string getName() const { return "server"; }
     bool isInitialized() const { return initialized_; }
     const nlohmann::json& getConfig() const { return config_; }
+    const std::string& getLastErrorCode() const { return lastErrorCode_; }
+    const std::string& getLastErrorMessage() const { return lastErrorMessage_; }
 
 private:
-    nlohmann::json config_;
+    void setLastError(std::string code, std::string message);
+    void clearLastError();
+
+    nlohmann::json config_ = nlohmann::json::object();
     bool initialized_ = false;
+    std::string healthPath_ = "/api/server/health";
+    std::string statusPath_ = "/api/server/status";
+    std::string lastErrorCode_;
+    std::string lastErrorMessage_;
+    std::shared_ptr<BaseClient> client_;
 };
 
 } // namespace eliza_api_client

--- a/cpp/packages/applications/eliza/packages/api-client/src/services/system.cpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/services/system.cpp
@@ -1,25 +1,133 @@
 #include "system.hpp"
 
+#include <utility>
+
 namespace elizaos {
 namespace eliza_api_client {
 
+namespace {
+std::string stringValueOrDefault(const nlohmann::json& config,
+                                 const std::string& camelKey,
+                                 const std::string& snakeKey,
+                                 const std::string& defaultValue) {
+    const auto camelIt = config.find(camelKey);
+    if (camelIt != config.end() && camelIt->is_string() && !camelIt->get<std::string>().empty()) {
+        return camelIt->get<std::string>();
+    }
+
+    const auto snakeIt = config.find(snakeKey);
+    if (snakeIt != config.end() && snakeIt->is_string() && !snakeIt->get<std::string>().empty()) {
+        return snakeIt->get<std::string>();
+    }
+
+    return defaultValue;
+}
+} // namespace
+
+System::System(std::shared_ptr<BaseClient> client)
+    : client_(std::move(client)) {}
+
 bool System::initialize(const nlohmann::json& config) {
-    if (initialized_) return true;
+    if (initialized_) {
+        return true;
+    }
+
+    if (!config.is_object()) {
+        setLastError("invalid_config", "System service configuration must be a JSON object.");
+        return false;
+    }
+
     config_ = config;
+    configPath_ = stringValueOrDefault(config_, "configPath", "config_path", "/api/system/config");
+    infoPath_ = stringValueOrDefault(config_, "infoPath", "info_path", "/api/system/info");
+    metricsPath_ = stringValueOrDefault(config_, "metricsPath", "metrics_path", "/api/system/metrics");
+    config_["configPath"] = configPath_;
+    config_["infoPath"] = infoPath_;
+    config_["metricsPath"] = metricsPath_;
+
+    if (!client_) {
+        client_ = std::make_shared<BaseClient>();
+    }
+
+    if (!client_->isInitialized()) {
+        if (!client_->initialize(config_)) {
+            setLastError(client_->getLastErrorCode().empty() ? "client_initialization_failed" : client_->getLastErrorCode(),
+                         client_->getLastErrorMessage().empty() ? "System service could not initialize its BaseClient." : client_->getLastErrorMessage());
+            initialized_ = false;
+            return false;
+        }
+    }
+
     initialized_ = true;
+    clearLastError();
     return true;
 }
 
 void System::shutdown() {
     initialized_ = false;
-    config_ = {};
+    config_ = nlohmann::json::object();
+    configPath_ = "/api/system/config";
+    infoPath_ = "/api/system/info";
+    metricsPath_ = "/api/system/metrics";
+    clearLastError();
+}
+
+void System::setClient(std::shared_ptr<BaseClient> client) {
+    client_ = std::move(client);
+}
+
+ApiResult System::getConfig() const {
+    if (!initialized_) {
+        return ApiResult::failure("system_not_initialized", "System service must be initialized before config can be requested.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "System service has no BaseClient configured.");
+    }
+    return client_->request("GET", configPath_);
+}
+
+ApiResult System::getInfo() const {
+    if (!initialized_) {
+        return ApiResult::failure("system_not_initialized", "System service must be initialized before info can be requested.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "System service has no BaseClient configured.");
+    }
+    return client_->request("GET", infoPath_);
+}
+
+ApiResult System::getMetrics() const {
+    if (!initialized_) {
+        return ApiResult::failure("system_not_initialized", "System service must be initialized before metrics can be requested.");
+    }
+    if (!client_) {
+        return ApiResult::failure("client_missing", "System service has no BaseClient configured.");
+    }
+    return client_->request("GET", metricsPath_);
 }
 
 nlohmann::json System::getStatus() const {
     nlohmann::json status;
     status["name"] = getName();
     status["initialized"] = initialized_;
+    status["configPath"] = configPath_;
+    status["infoPath"] = infoPath_;
+    status["metricsPath"] = metricsPath_;
+    status["clientConfigured"] = static_cast<bool>(client_);
+    status["client"] = client_ ? client_->getStatus() : nlohmann::json::object();
+    status["lastErrorCode"] = lastErrorCode_;
+    status["lastErrorMessage"] = lastErrorMessage_;
     return status;
+}
+
+void System::setLastError(std::string code, std::string message) {
+    lastErrorCode_ = std::move(code);
+    lastErrorMessage_ = std::move(message);
+}
+
+void System::clearLastError() {
+    lastErrorCode_.clear();
+    lastErrorMessage_.clear();
 }
 
 } // namespace eliza_api_client

--- a/cpp/packages/applications/eliza/packages/api-client/src/services/system.hpp
+++ b/cpp/packages/applications/eliza/packages/api-client/src/services/system.hpp
@@ -9,24 +9,65 @@
 #include <optional>
 #include <nlohmann/json.hpp>
 
+#include "../lib/base-client.hpp"
+
 namespace elizaos {
 namespace eliza_api_client {
 
+/**
+ * System service for querying system-level information and configuration.
+ * 
+ * This service provides endpoints for:
+ * - System configuration
+ * - Runtime information
+ * - System metrics
+ */
 class System {
 public:
     System() = default;
+    explicit System(std::shared_ptr<BaseClient> client);
     ~System() = default;
 
     bool initialize(const nlohmann::json& config = {});
     void shutdown();
+
+    void setClient(std::shared_ptr<BaseClient> client);
+    std::shared_ptr<BaseClient> getClient() const { return client_; }
+
+    /**
+     * Get system configuration.
+     */
+    ApiResult getConfig() const;
+
+    /**
+     * Get system runtime information (uptime, version, etc.).
+     */
+    ApiResult getInfo() const;
+
+    /**
+     * Get system metrics (memory usage, active connections, etc.).
+     */
+    ApiResult getMetrics() const;
+
     nlohmann::json getStatus() const;
     std::string getName() const { return "system"; }
     bool isInitialized() const { return initialized_; }
-    const nlohmann::json& getConfig() const { return config_; }
+    const nlohmann::json& getServiceConfig() const { return config_; }
+    const std::string& getLastErrorCode() const { return lastErrorCode_; }
+    const std::string& getLastErrorMessage() const { return lastErrorMessage_; }
 
 private:
-    nlohmann::json config_;
+    void setLastError(std::string code, std::string message);
+    void clearLastError();
+
+    nlohmann::json config_ = nlohmann::json::object();
     bool initialized_ = false;
+    std::string configPath_ = "/api/system/config";
+    std::string infoPath_ = "/api/system/info";
+    std::string metricsPath_ = "/api/system/metrics";
+    std::string lastErrorCode_;
+    std::string lastErrorMessage_;
+    std::shared_ptr<BaseClient> client_;
 };
 
 } // namespace eliza_api_client

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -354,6 +354,7 @@ target_include_directories(api_client_real_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/cpp/include
 )
+find_package(CURL REQUIRED)
 target_link_libraries(api_client_real_test
     elizaos-eliza-api-client
     gtest
@@ -362,6 +363,24 @@ target_link_libraries(api_client_real_test
     Threads::Threads
 )
 add_test(NAME api_client_real_test COMMAND api_client_real_test)
+
+# Targeted api-client Feature Garden Ledger tests: truthful BaseClient + ServerService vertical slice.
+add_executable(real_api_client_test src/test_api_client.cpp src/shim_main.cpp)
+target_include_directories(real_api_client_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/cpp/include
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/cpp/packages/applications/eliza/packages/api-client/src
+)
+find_package(CURL REQUIRED)
+target_link_libraries(real_api_client_test
+    elizaos-eliza-api-client
+    gtest
+    nlohmann_json::nlohmann_json
+    CURL::libcurl
+    Threads::Threads
+)
+add_test(NAME real_api_client_test COMMAND real_api_client_test)
+
 add_executable(public_header_forwarding_all_test
     public_header_forwarding_all_test.cpp
     public_header_forwarding_headers/agentaction_hpp_test.cpp
@@ -440,6 +459,16 @@ add_test(NAME public_header_forwarding_all_test COMMAND public_header_forwarding
 # centers and the cognitive integration anchor without compiling the generated
 # forest first.
 set(ELIZAOS_KSM_CANONICAL_TEST_TARGETS
+    agentaction_test
+    agentagenda_test
+    agentbrowser_test
+    agentcomms_test
+    agentloop_test
+    agentmemory_test
+    agentshell_test
+    characters_test
+    core_test
+    knowledge_test
     cognitive_pipeline_e2e_test
     real_core_test
     real_agentaction_test
@@ -456,6 +485,7 @@ set(ELIZAOS_KSM_CANONICAL_TEST_TARGETS
     plugin_specification_test
     public_header_forwarding_test
     api_client_real_test
+    real_api_client_test
     public_header_forwarding_all_test
 )
 

--- a/cpp/tests/src/test_api_client.cpp
+++ b/cpp/tests/src/test_api_client.cpp
@@ -1,0 +1,258 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "client.hpp"
+#include "lib/base-client.hpp"
+#include "services/server.hpp"
+
+namespace {
+
+using elizaos::eliza_api_client::ApiResult;
+using elizaos::eliza_api_client::BaseClient;
+using elizaos::eliza_api_client::Client;
+using elizaos::eliza_api_client::HttpRequest;
+using elizaos::eliza_api_client::HttpResponse;
+using elizaos::eliza_api_client::IHttpTransport;
+using elizaos::eliza_api_client::Server;
+
+class FakeTransport final : public IHttpTransport {
+public:
+    explicit FakeTransport(bool ready = true)
+        : ready_(ready) {}
+
+    ApiResult send(const HttpRequest& request) override {
+        requests.push_back(request);
+        HttpResponse response;
+        response.statusCode = statusCode;
+        response.body = responseBody;
+        response.jsonBody = responseJson;
+        return ApiResult::success(response);
+    }
+
+    bool isReady() const override { return ready_; }
+    std::string getName() const override { return "fake_transport"; }
+
+    bool ready_ = true;
+    int statusCode = 200;
+    std::string responseBody = R"({"ok":true})";
+    nlohmann::json responseJson = {{"ok", true}};
+    std::vector<HttpRequest> requests;
+};
+
+nlohmann::json validConfig() {
+    return {
+        {"baseUrl", "https://eliza.example.test/"},
+        {"timeoutMs", 1500},
+        {"maxRetries", 1}
+    };
+}
+
+TEST(ApiClientBaseClientTest, EmptyConfigDoesNotInitialize) {
+    BaseClient client;
+
+    EXPECT_FALSE(client.initialize(nlohmann::json::object()));
+    EXPECT_FALSE(client.isInitialized());
+    EXPECT_FALSE(client.isConfigured());
+    EXPECT_EQ(client.getLastErrorCode(), "base_url_missing");
+
+    const auto status = client.getStatus();
+    EXPECT_FALSE(status.at("initialized").get<bool>());
+    EXPECT_FALSE(status.at("configured").get<bool>());
+}
+
+TEST(ApiClientBaseClientTest, ValidConfigInitializesButReportsMissingTransport) {
+    BaseClient client;
+
+    ASSERT_TRUE(client.initialize(validConfig()));
+    EXPECT_TRUE(client.isInitialized());
+    EXPECT_TRUE(client.isConfigured());
+    EXPECT_EQ(client.getBaseUrl(), "https://eliza.example.test");
+    EXPECT_FALSE(client.isTransportReady());
+
+    const auto status = client.getStatus();
+    EXPECT_TRUE(status.at("initialized").get<bool>());
+    EXPECT_TRUE(status.at("configured").get<bool>());
+    EXPECT_FALSE(status.at("transportConfigured").get<bool>());
+    EXPECT_FALSE(status.at("transportReady").get<bool>());
+}
+
+TEST(ApiClientBaseClientTest, RequestWithoutTransportFailsTruthfully) {
+    BaseClient client;
+    ASSERT_TRUE(client.initialize(validConfig()));
+
+    const ApiResult result = client.request("GET", "/api/server/health");
+
+    EXPECT_FALSE(result.ok);
+    EXPECT_EQ(result.errorCode, "transport_missing");
+    EXPECT_EQ(result.response.statusCode, 0);
+}
+
+TEST(ApiClientBaseClientTest, FakeTransportReceivesNormalizedRequestAndReturnsApiResult) {
+    auto transport = std::make_shared<FakeTransport>();
+    BaseClient client(transport);
+    ASSERT_TRUE(client.initialize(validConfig()));
+
+    const nlohmann::json body = {{"message", "hello"}};
+    const ApiResult result = client.request("POST", "api/messages", body, {{"X-Test", "yes"}});
+
+    ASSERT_TRUE(result.ok);
+    EXPECT_EQ(result.response.statusCode, 200);
+    EXPECT_EQ(result.response.jsonBody.at("ok"), true);
+    ASSERT_EQ(transport->requests.size(), 1U);
+    EXPECT_EQ(transport->requests.front().method, "POST");
+    EXPECT_EQ(transport->requests.front().path, "api/messages");
+    EXPECT_EQ(transport->requests.front().url, "https://eliza.example.test/api/messages");
+    EXPECT_EQ(transport->requests.front().body.at("message"), "hello");
+    EXPECT_EQ(transport->requests.front().headers.at("X-Test"), "yes");
+}
+
+TEST(ApiClientServerServiceTest, HealthUsesBaseClientTransportPath) {
+    auto transport = std::make_shared<FakeTransport>();
+    auto client = std::make_shared<BaseClient>(transport);
+    ASSERT_TRUE(client->initialize(validConfig()));
+
+    Server server(client);
+    ASSERT_TRUE(server.initialize(nlohmann::json::object()));
+
+    const ApiResult result = server.getHealth();
+
+    ASSERT_TRUE(result.ok);
+    ASSERT_EQ(transport->requests.size(), 1U);
+    EXPECT_EQ(transport->requests.front().method, "GET");
+    EXPECT_EQ(transport->requests.front().path, "/api/server/health");
+    EXPECT_EQ(transport->requests.front().url, "https://eliza.example.test/api/server/health");
+}
+
+TEST(ApiClientServerServiceTest, ServerStatusUsesConfigurableStatusPath) {
+    auto transport = std::make_shared<FakeTransport>();
+    auto client = std::make_shared<BaseClient>(transport);
+    ASSERT_TRUE(client->initialize(validConfig()));
+
+    Server server(client);
+    ASSERT_TRUE(server.initialize({{"statusPath", "/custom/status"}, {"healthPath", "/custom/health"}}));
+
+    const ApiResult result = server.getServerStatus();
+
+    ASSERT_TRUE(result.ok);
+    ASSERT_EQ(transport->requests.size(), 1U);
+    EXPECT_EQ(transport->requests.front().method, "GET");
+    EXPECT_EQ(transport->requests.front().path, "/custom/status");
+    EXPECT_EQ(transport->requests.front().url, "https://eliza.example.test/custom/status");
+
+    const auto status = server.getStatus();
+    EXPECT_TRUE(status.at("initialized").get<bool>());
+    EXPECT_EQ(status.at("healthPath"), "/custom/health");
+    EXPECT_EQ(status.at("statusPath"), "/custom/status");
+    EXPECT_TRUE(status.at("clientConfigured").get<bool>());
+}
+
+TEST(ApiClientClientBoundaryTest, InitializesWithCanonicalBaseUrlAndStatusSnapshot) {
+    Client client;
+
+    nlohmann::json config = {
+        {"baseUrl", "https://agent.example.test/api/"},
+        {"timeoutMs", 12000},
+        {"headers", {
+            {"X-Agent", "eliza"},
+            {"X-Number-Ignored", 7}
+        }}
+    };
+
+    ASSERT_TRUE(client.initialize(config));
+    EXPECT_TRUE(client.isInitialized());
+    EXPECT_EQ(client.getBaseUrl(), "https://agent.example.test/api");
+    EXPECT_EQ(client.getTimeoutMs(), 12000);
+    ASSERT_EQ(client.getDefaultHeaders().size(), 1u);
+    EXPECT_EQ(client.getDefaultHeaders().at("X-Agent"), "eliza");
+
+    const auto status = client.getStatus();
+    EXPECT_EQ(status.at("name"), "client");
+    EXPECT_EQ(status.at("initialized"), true);
+    EXPECT_EQ(status.at("baseUrl"), "https://agent.example.test/api");
+    EXPECT_EQ(status.at("timeoutMs"), 12000);
+    EXPECT_EQ(status.at("headerCount"), 1u);
+    EXPECT_EQ(status.at("defaultHeaders").at("X-Agent"), "eliza");
+}
+
+TEST(ApiClientClientBoundaryTest, ResolvesRelativeRootQueryAndAbsoluteEndpoints) {
+    Client client;
+    ASSERT_TRUE(client.initialize({{"base_url", "http://localhost:3000///"}}));
+
+    EXPECT_EQ(client.resolveEndpoint(""), "http://localhost:3000");
+    EXPECT_EQ(client.resolveEndpoint("/"), "http://localhost:3000");
+    EXPECT_EQ(client.resolveEndpoint("agents"), "http://localhost:3000/agents");
+    EXPECT_EQ(client.resolveEndpoint("/agents/42"), "http://localhost:3000/agents/42");
+    EXPECT_EQ(client.resolveEndpoint("?health=true"), "http://localhost:3000?health=true");
+    EXPECT_EQ(client.resolveEndpoint("https://override.example/status"),
+              "https://override.example/status");
+}
+
+TEST(ApiClientClientBoundaryTest, RedactsAuthMaterialFromStatus) {
+    Client client;
+    ASSERT_TRUE(client.initialize({
+        {"baseUrl", "https://secure.example.test"},
+        {"apiKey", "sk-secret-value"},
+        {"bearer_token", "bearer-secret-value"}
+    }));
+
+    EXPECT_TRUE(client.hasApiKey());
+    EXPECT_TRUE(client.hasBearerToken());
+    EXPECT_TRUE(client.hasAuth());
+
+    const std::string status_dump = client.getStatus().dump();
+    EXPECT_NE(status_dump.find("\"hasApiKey\":true"), std::string::npos);
+    EXPECT_NE(status_dump.find("\"hasBearerToken\":true"), std::string::npos);
+    EXPECT_EQ(status_dump.find("sk-secret-value"), std::string::npos);
+    EXPECT_EQ(status_dump.find("bearer-secret-value"), std::string::npos);
+}
+
+TEST(ApiClientClientBoundaryTest, RejectsMissingInvalidBaseUrlAndInvalidTimeout) {
+    Client client;
+
+    EXPECT_THROW(client.initialize({}), std::invalid_argument);
+    EXPECT_THROW(client.initialize({{"baseUrl", ""}}), std::invalid_argument);
+    EXPECT_THROW(client.initialize({{"baseUrl", "localhost:3000"}}), std::invalid_argument);
+    EXPECT_THROW(client.initialize({{"baseUrl", "ftp://example.test"}}), std::invalid_argument);
+    EXPECT_THROW(client.initialize({{"baseUrl", "https://example.test"}, {"timeoutMs", 0}}),
+                 std::invalid_argument);
+    EXPECT_THROW(client.initialize({{"baseUrl", "https://example.test"}, {"timeoutMs", "slow"}}),
+                 std::invalid_argument);
+
+    EXPECT_FALSE(client.isInitialized());
+    EXPECT_EQ(client.getStatus().at("initialized"), false);
+    EXPECT_TRUE(client.getStatus().at("baseUrl").is_null());
+}
+
+TEST(ApiClientClientBoundaryTest, ShutdownClearsDerivedRuntimeState) {
+    Client client;
+    ASSERT_TRUE(client.initialize({
+        {"baseUrl", "https://agent.example.test"},
+        {"api_key", "secret"},
+        {"timeout_ms", 5000},
+        {"headers", {{"X-Agent", "eliza"}}}
+    }));
+
+    client.shutdown();
+
+    EXPECT_FALSE(client.isInitialized());
+    EXPECT_EQ(client.getBaseUrl(), "");
+    EXPECT_EQ(client.getTimeoutMs(), 30000);
+    EXPECT_FALSE(client.hasAuth());
+    EXPECT_TRUE(client.getDefaultHeaders().empty());
+    EXPECT_THROW(client.resolveEndpoint("agents"), std::logic_error);
+}
+
+TEST(ApiClientClientBoundaryTest, InitializeIsIdempotentAfterSuccessfulInitialization) {
+    Client client;
+    ASSERT_TRUE(client.initialize({{"baseUrl", "https://first.example.test"}}));
+    ASSERT_TRUE(client.initialize({{"baseUrl", "https://second.example.test"}}));
+
+    EXPECT_EQ(client.getBaseUrl(), "https://first.example.test");
+    EXPECT_EQ(client.resolveEndpoint("status"), "https://first.example.test/status");
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

This repair restores a truthful API-client/server boundary in the canonical nested layout by porting the real transport seam and richer API-client validation from the flattened fork.

Key changes include:

- Adds the libcurl-backed `CurlTransport` implementation.
- Restores request routing through `BaseClient`/service methods instead of initialized-status stubs.
- Expands URL normalization, redacted auth status, timeout, deterministic shutdown, and fake-transport request-shape coverage.
- Updates KSM aggregate dependencies so all registered KSM tests build before `ctest -L ksm`.

## Validation

- `cmake -S o9nn-elizaos-cpp -B o9nn-elizaos-cpp/build-kstm -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build o9nn-elizaos-cpp/build-kstm --target ksm_canonical_tests -j2`
- `ctest --test-dir o9nn-elizaos-cpp/build-kstm --output-on-failure -L ksm`

Result: 31/31 KSM-labeled tests passed.
