### PR TITLE
Repair autonomy lifecycle resume and shell history semantics

### DIFF
--- a/cpp/packages/core/agentloop/src/agentloop.cpp
+++ b/cpp/packages/core/agentloop/src/agentloop.cpp
@@ -120,6 +120,7 @@ void AgentLoop::pause() {
 
 void AgentLoop::unpause() {
     pauseRequested_ = false;
+    stepEvent_.notify_all();
 }
 
 bool AgentLoop::isRunning() const {

--- a/cpp/packages/infrastructure/agentshell/src/agentshell.cpp
+++ b/cpp/packages/infrastructure/agentshell/src/agentshell.cpp
@@ -39,17 +39,20 @@ void AgentShell::start(const std::string& prompt) {
 }
 
 void AgentShell::stop() {
-    if (!running_) {
-        return;
-    }
-    
-    running_ = false;
+    const bool wasRunning = running_.exchange(false);
     
     if (shellThread_ && shellThread_->joinable()) {
-        shellThread_->join();
+        if (shellThread_->get_id() != std::this_thread::get_id()) {
+            shellThread_->join();
+        } else {
+            shellThread_->detach();
+        }
     }
+    shellThread_.reset();
     
-    logInfo("Interactive shell stopped", "agentshell");
+    if (wasRunning) {
+        logInfo("Interactive shell stopped", "agentshell");
+    }
 }
 
 void AgentShell::shellLoop() {
@@ -89,13 +92,8 @@ void AgentShell::shellLoop() {
             continue;
         }
         
-        // Add to internal history
-        if (historyEnabled_) {
-            std::lock_guard<std::mutex> lock(historyMutex_);
-            commandHistory_.push_back(command);
-        }
-        
-        // Execute command
+        // Execute command. executeCommand() is the single owner of internal
+        // history recording, so interactive commands are not double-counted.
         auto result = executeCommand(command);
         
         // Display result

--- a/cpp/tests/agentshell_test.cpp
+++ b/cpp/tests/agentshell_test.cpp
@@ -2,6 +2,13 @@
 #include <gtest/gtest.h>
 #include "elizaos/agentshell.hpp"
 
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <sstream>
+#include <thread>
+#include <vector>
+
 using namespace elizaos;
 
 class AgentShellTest : public ::testing::Test {
@@ -82,6 +89,33 @@ TEST_F(AgentShellTest, SetPromptDoesNotThrow) {
 TEST_F(AgentShellTest, IsRunningInitiallyFalse) {
     EXPECT_FALSE(shell.isRunning());
 }
+
+#ifndef HAVE_READLINE
+TEST(AgentShellInteractive, StartConsumesFiniteInputJoinsCleanlyAndRecordsHistoryOnce) {
+    AgentShell interactiveShell;
+    interactiveShell.setHistoryEnabled(true);
+
+    std::istringstream scriptedInput("echo interactive lifecycle\nexit\n");
+    std::ostringstream capturedOutput;
+    auto* originalCin = std::cin.rdbuf(scriptedInput.rdbuf());
+    auto* originalCout = std::cout.rdbuf(capturedOutput.rdbuf());
+
+    interactiveShell.start("test> ");
+    for (int attempt = 0; attempt < 100 && interactiveShell.isRunning(); ++attempt) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    interactiveShell.stop();
+
+    std::cout.rdbuf(originalCout);
+    std::cin.rdbuf(originalCin);
+
+    EXPECT_FALSE(interactiveShell.isRunning());
+    const auto history = interactiveShell.getHistory();
+    EXPECT_EQ(1u, static_cast<unsigned>(std::count(history.begin(), history.end(), "echo interactive lifecycle")));
+    EXPECT_EQ(1u, static_cast<unsigned>(std::count(history.begin(), history.end(), "exit")));
+    EXPECT_NE(capturedOutput.str().find("interactive lifecycle"), std::string::npos);
+}
+#endif
 
 TEST(AgentShellGlobals, GlobalShellExists) {
     ASSERT_NE(globalShell, nullptr);


### PR DESCRIPTION
## Summary

This repair synchronizes two autonomy lifecycle fixes across the C++ layouts:

- wakes `AgentLoop` workers on `unpause()` so pause/resume cycles cannot strand an autonomous loop blocked in the pause wait state;
- hardens `AgentShell` lifecycle restart behavior by joining completed shell threads before restart;
- prevents duplicate scripted shell history ownership when the interactive shell loop delegates command execution;
- adds scripted AgentShell regression coverage for finite-input shutdown and single-owner command history semantics.

## Validation

Focused autonomy CTest subsets passed in both repositories after the repair:

- `agentaction_test`
- `agentagenda_test`
- `agentbrowser_test`
- `agentcomms_test`
- `agentloop_test`
- `agentmemory_test`
- `agentshell_test`
- `api_client_real_test`

Both runs reported `100% tests passed, 0 tests failed out of 8`.
