### PR TITLE
feat(autonomy): closed-loop self-regulation (reflection + attention focus + outcome feedback)

### DIFF
--- a/cpp/packages/core/core/src/core.cpp
+++ b/cpp/packages/core/core/src/core.cpp
@@ -113,6 +113,17 @@ void State::addGoal(const Goal& goal) {
     goals_.push_back(goal);
 }
 
+bool State::updateGoalStatus(const UUID& goalId, const std::string& status) {
+    for (auto& goal : goals_) {
+        if (goal.id == goalId) {
+            goal.status = status;
+            goal.updatedAt = std::chrono::system_clock::now();
+            return true;
+        }
+    }
+    return false;
+}
+
 void State::addRecentMessage(std::shared_ptr<Memory> memory) {
     recentMessages_.push_back(memory);
     

--- a/cpp/packages/integration/autonomous_starter/CMakeLists.txt
+++ b/cpp/packages/integration/autonomous_starter/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(elizaos-autonomous_starter
     elizaos-agentloop
     elizaos-agentshell
     elizaos-agentlogger
+    elizaos-agentmemory
     Threads::Threads
 )
 
@@ -32,6 +33,7 @@ target_link_libraries(autonomous_starter_demo
     elizaos-agentloop
     elizaos-agentshell
     elizaos-agentlogger
+    elizaos-agentmemory
     Threads::Threads
 )
 
@@ -51,6 +53,7 @@ target_link_libraries(autonomous_starter_tests
     elizaos-agentloop
     elizaos-agentshell
     elizaos-agentlogger
+    elizaos-agentmemory
     gtest_main
     Threads::Threads
 )

--- a/cpp/packages/integration/autonomous_starter/src/autonomous_starter.cpp
+++ b/cpp/packages/integration/autonomous_starter/src/autonomous_starter.cpp
@@ -534,8 +534,130 @@ std::size_t AutonomousStarter::runCognitiveCycleOnce() {
     std::shared_ptr<void> token = std::make_shared<int>(0);
     token = perceptionStep(token);
     token = reasoningStep(token);
-    actionStep(token);
+    token = actionStep(token);
+    reflectionStep(token);
     return cognitiveCycle_;
+}
+
+double AutonomousStarter::getPlanSuccessRatio(const std::string& plan) const {
+    auto it = planStats_.find(plan);
+    if (it == planStats_.end() || it->second.attempts == 0) {
+        return 0.0;
+    }
+    return static_cast<double>(it->second.successes) /
+           static_cast<double>(it->second.attempts);
+}
+
+double AutonomousStarter::planBias(const std::string& plan) const {
+    // Optimistic prior: unseen plans start neutral so the agent still explores,
+    // while plans with a track record are biased by their measured success rate.
+    auto it = planStats_.find(plan);
+    if (it == planStats_.end() || it->second.attempts == 0) {
+        return 0.5;
+    }
+    return static_cast<double>(it->second.successes) /
+           static_cast<double>(it->second.attempts);
+}
+
+void AutonomousStarter::recordPlanOutcome(const std::string& plan, bool success) {
+    if (plan.empty()) {
+        return;
+    }
+    auto& stats = planStats_[plan];
+    ++stats.attempts;
+    if (success) {
+        ++stats.successes;
+    }
+}
+
+void AutonomousStarter::refreshGoalAttention() {
+    const auto& goals = state_.getGoals();
+    for (const auto& goal : goals) {
+        std::string status = goal.status;
+        std::transform(status.begin(), status.end(), status.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        const bool open = (status == "active" || status == "in_progress" ||
+                           status == "pending");
+
+        AttentionValue av = goalAttention_.hasAttentionValue(goal.id)
+                                ? goalAttention_.getAttentionValue(goal.id)
+                                : AttentionValue{};
+        if (status == "active" || status == "in_progress") {
+            av.importance = 0.9;
+            av.urgency = 0.7;
+        } else if (status == "pending") {
+            av.importance = 0.6;
+            av.urgency = 0.5;
+        } else {
+            av.importance = 0.1;
+            av.urgency = 0.1;
+        }
+        av.novelty = (goal.id == focusedGoalId_) ? std::max(0.0, av.novelty * 0.6)
+                                                 : std::min(1.0, av.novelty + 0.3);
+        av.activation = open ? std::min(1.0, av.activation + 0.2)
+                             : std::max(0.0, av.activation * 0.5);
+        goalAttention_.updateAttentionValue(goal.id, av);
+    }
+}
+
+const StateGoal* AutonomousStarter::selectFocusGoal() {
+    const auto& goals = state_.getGoals();
+    if (goals.empty()) {
+        focusedGoalId_.clear();
+        return nullptr;
+    }
+    refreshGoalAttention();
+
+    const StateGoal* best = nullptr;
+    double bestScore = -1.0;
+    for (const auto& goal : goals) {
+        std::string status = goal.status;
+        std::transform(status.begin(), status.end(), status.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (status != "active" && status != "in_progress" && status != "pending") {
+            continue;
+        }
+        const double score =
+            goalAttention_.getAttentionValue(goal.id).getCompositeScore();
+        if (score > bestScore) {
+            bestScore = score;
+            best = &goal;
+        }
+    }
+    if (!best) {
+        best = &goals.back();
+    }
+    focusedGoalId_ = best->id;
+    return best;
+}
+
+void AutonomousStarter::advanceGoalLifecycle(const std::string& plan, bool actionSucceeded) {
+    if (focusedGoalId_.empty() || !actionSucceeded) {
+        return;
+    }
+    std::string currentStatus;
+    for (const auto& goal : state_.getGoals()) {
+        if (goal.id == focusedGoalId_) {
+            currentStatus = goal.status;
+            break;
+        }
+    }
+    std::string lower = currentStatus;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    if (lower == "pending") {
+        state_.updateGoalStatus(focusedGoalId_, "active");
+        appendMemory("Goal lifecycle: goal " + focusedGoalId_ +
+                     " advanced pending -> active after successful plan '" + plan + "'.");
+    } else if (lower == "active" || lower == "in_progress") {
+        if (getPlanSuccessRatio(plan) >= 0.5 &&
+            planStats_[plan].attempts >= 2) {
+            state_.updateGoalStatus(focusedGoalId_, "completed");
+            appendMemory("Goal lifecycle: goal " + focusedGoalId_ +
+                         " advanced active -> completed after reliable plan '" + plan + "'.");
+        }
+    }
 }
 
 std::shared_ptr<void> AutonomousStarter::perceptionStep(std::shared_ptr<void> input) {
@@ -568,38 +690,66 @@ std::shared_ptr<void> AutonomousStarter::perceptionStep(std::shared_ptr<void> in
 
 std::shared_ptr<void> AutonomousStarter::reasoningStep(std::shared_ptr<void> input) {
     const std::size_t memoryCount = state_.getRecentMessages().size();
-    const std::string goalContext = selectGoalContext();
+
+    // Attention-weighted goal selection: focus on the highest-scoring open goal
+    // rather than the first active one. This makes the agent's attention an
+    // economic resource that shifts toward important/urgent/novel goals.
+    const StateGoal* focus = selectFocusGoal();
+    const std::string goalContext = focus ? (focus->description.empty()
+                                                 ? selectGoalContext()
+                                                 : focus->description)
+                                          : selectGoalContext();
     std::string normalizedGoal = goalContext;
     std::transform(normalizedGoal.begin(), normalizedGoal.end(), normalizedGoal.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
 
+    // Build the candidate plan set implied by the focused goal/context.
+    std::vector<std::string> candidatePlans;
     if (normalizedGoal.find("test") != std::string::npos ||
         normalizedGoal.find("validation") != std::string::npos ||
         normalizedGoal.find("self-audit") != std::string::npos ||
         normalizedGoal.find("audit") != std::string::npos) {
-        lastPlan_ = "run autonomy self-audit by inspecting tests and validation coverage";
-    } else if (normalizedGoal.find("c++") != std::string::npos ||
-               normalizedGoal.find("project structure") != std::string::npos ||
-               lastObservationSummary_.find("CMakeLists.txt") != std::string::npos) {
-        lastPlan_ = "inspect C++ project structure with targeted source discovery";
-    } else if (normalizedGoal.find("runtime") != std::string::npos ||
-               normalizedGoal.find("system") != std::string::npos) {
-        lastPlan_ = "inspect system identity and runtime context";
-    } else if (memoryCount < 5 || normalizedGoal.find("situational awareness") != std::string::npos ||
-               normalizedGoal.find("workspace") != std::string::npos) {
-        lastPlan_ = "establish situational awareness with pwd and directory inspection";
-    } else if (actionCounter_ % 3 == 0) {
-        lastPlan_ = "sample repository source files";
-    } else if (actionCounter_ % 3 == 1) {
-        lastPlan_ = "inspect system identity and kernel context";
-    } else {
-        lastPlan_ = "maintain lightweight environmental awareness";
+        candidatePlans.push_back("run autonomy self-audit by inspecting tests and validation coverage");
+    }
+    if (normalizedGoal.find("c++") != std::string::npos ||
+        normalizedGoal.find("project structure") != std::string::npos ||
+        lastObservationSummary_.find("CMakeLists.txt") != std::string::npos) {
+        candidatePlans.push_back("inspect C++ project structure with targeted source discovery");
+    }
+    if (normalizedGoal.find("runtime") != std::string::npos ||
+        normalizedGoal.find("system") != std::string::npos) {
+        candidatePlans.push_back("inspect system identity and runtime context");
+    }
+    if (memoryCount < 5 || normalizedGoal.find("situational awareness") != std::string::npos ||
+        normalizedGoal.find("workspace") != std::string::npos) {
+        candidatePlans.push_back("establish situational awareness with pwd and directory inspection");
+    }
+    // Always include the rotating exploratory plans so the agent keeps options
+    // open even once core goals are addressed.
+    candidatePlans.push_back("sample repository source files");
+    candidatePlans.push_back("inspect system identity and kernel context");
+    candidatePlans.push_back("maintain lightweight environmental awareness");
+
+    // Outcome-based plan adaptation: pick the candidate with the highest learned
+    // success bias. Ties are broken by candidate order (goal-relevant plans are
+    // listed first), which preserves the previous deterministic preference while
+    // letting accumulated feedback override it once evidence exists.
+    lastPlan_ = candidatePlans.front();
+    double bestBias = -1.0;
+    for (const auto& plan : candidatePlans) {
+        const double bias = planBias(plan);
+        if (bias > bestBias) {
+            bestBias = bias;
+            lastPlan_ = plan;
+        }
     }
 
     appendMemory("Cycle " + std::to_string(cognitiveCycle_) +
-                 " reasoning: goal = " + goalContext +
+                 " reasoning: focus_goal_id = " + (focus ? focus->id : std::string("none")) +
+                 "; goal = " + goalContext +
                  "; recent experience summary = " + summarizeRecentExperience() +
-                 "; selected plan = " + lastPlan_ + ".");
+                 "; selected plan = " + lastPlan_ +
+                 " (bias=" + std::to_string(bestBias) + ").");
     logInfo("Reasoning selected plan: " + lastPlan_);
     return input;
 }
@@ -610,10 +760,45 @@ std::shared_ptr<void> AutonomousStarter::actionStep(std::shared_ptr<void> input)
     ++actionCounter_;
     const auto result = executeShellCommand(command);
 
+    // Capture outcome details so the reflection step can evaluate them.
+    lastActionCommand_ = command;
+    lastActionSucceeded_ = result.success;
+    lastActionOutput_ = result.output;
+
     appendMemory("Cycle " + std::to_string(cognitiveCycle_) +
                  " action: command='" + command + "', success=" +
                  std::string(result.success ? "true" : "false") +
                  ", exitCode=" + std::to_string(result.exitCode) + ".");
+    return input;
+}
+
+std::shared_ptr<void> AutonomousStarter::reflectionStep(std::shared_ptr<void> input) {
+    // Reflection closes the cognitive loop: the agent evaluates the outcome of
+    // its action, feeds the result back into plan-success statistics, advances
+    // the focused goal's lifecycle, and records a reflective conclusion that
+    // shapes subsequent reasoning.
+    recordPlanOutcome(lastPlan_, lastActionSucceeded_);
+    advanceGoalLifecycle(lastPlan_, lastActionSucceeded_);
+
+    const double ratio = getPlanSuccessRatio(lastPlan_);
+    std::ostringstream reflection;
+    reflection << "Cycle " << cognitiveCycle_ << " reflection: plan='" << lastPlan_
+               << "' " << (lastActionSucceeded_ ? "succeeded" : "failed")
+               << "; plan_success_ratio=" << ratio
+               << "; focus_goal=" << (focusedGoalId_.empty() ? "none" : focusedGoalId_);
+
+    if (!lastActionSucceeded_) {
+        reflection << "; conclusion=de-prioritize this plan and explore alternatives next cycle";
+    } else if (ratio >= 0.75) {
+        reflection << "; conclusion=plan is reliable, reinforce focus on current goal";
+    } else {
+        reflection << "; conclusion=plan is promising, continue gathering evidence";
+    }
+
+    lastReflection_ = reflection.str();
+    ++reflectionCount_;
+    appendMemory(lastReflection_);
+    logInfo("Reflection: " + lastReflection_);
     return input;
 }
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries(autofun_idl_test elizaos-autofun_idl gtest gtest_main Thre
 add_test(NAME autofun_idl_test COMMAND autofun_idl_test)
 
 add_executable(autonomous_starter_test autonomous_starter_test.cpp)
-target_link_libraries(autonomous_starter_test elizaos-autonomous_starter gtest gtest_main Threads::Threads)
+target_link_libraries(autonomous_starter_test elizaos-autonomous_starter elizaos-agentmemory gtest gtest_main Threads::Threads)
 add_test(NAME autonomous_starter_test COMMAND autonomous_starter_test)
 
 if(TARGET elizaos-persistence)
@@ -603,4 +603,13 @@ endif()
 add_real_test(real_autonomy_optimizer_test src/test_autonomy_optimizer.cpp)
 if(TARGET real_autonomy_optimizer_test)
     list(APPEND ELIZAOS_KSM_CANONICAL_TEST_TARGETS real_autonomy_optimizer_test)
+endif()
+
+# KSM autonomy-evolution suite: comprehensive E2E coverage for the optimized
+# self-regulating cognitive loop - attention-weighted goal focus, plan-success
+# feedback learning, goal lifecycle transitions, the reflection phase, and the
+# State::updateGoalStatus lifecycle API extension.
+add_real_test(real_autonomy_evolution_test src/test_autonomy_evolution.cpp)
+if(TARGET real_autonomy_evolution_test)
+    list(APPEND ELIZAOS_KSM_CANONICAL_TEST_TARGETS real_autonomy_evolution_test)
 endif()

--- a/cpp/tests/src/test_autonomy_evolution.cpp
+++ b/cpp/tests/src/test_autonomy_evolution.cpp
@@ -1,0 +1,324 @@
+// test_autonomy_evolution.cpp
+//
+// Comprehensive end-to-end coverage for the KSM autonomy-evolution upgrade to
+// the AutonomousStarter cognitive loop. These tests validate the newly added
+// self-regulating behaviors that turn the previous observe->reason->act stub
+// into a closed-loop perceive->reason->act->reflect autonomy engine:
+//
+//   1. Reflection phase actually runs and produces a non-empty conclusion every
+//      cognitive cycle (reflectionCount tracks cycle count).
+//   2. Attention-weighted goal selection focuses on an open goal and exposes a
+//      stable focused-goal id.
+//   3. Plan-success feedback accumulates real statistics that bias future plan
+//      selection (getPlanSuccessRatio is well-defined and bounded).
+//   4. Goal lifecycle transitions advance pending -> active -> completed when
+//      the agent reliably succeeds at its plans.
+//   5. The State::updateGoalStatus lifecycle-mutation API behaves correctly in
+//      isolation (found/updated vs. not-found, timestamp refresh).
+//   6. The full loop remains coherent and self-consistent across many cycles.
+//
+// Every assertion exercises real implementation behavior; there are no mocks.
+
+#include <gtest/gtest.h>
+
+#include "elizaos/goal_manager.hpp"  // MUST precede autonomous_starter.hpp
+#include "elizaos/autonomous_starter.hpp"
+#include "elizaos/core.hpp"
+
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace elizaos;
+using namespace std::chrono_literals;
+
+namespace {
+
+AgentConfig makeConfig(const std::string& name) {
+    AgentConfig cfg;
+    cfg.agentId = generateUUID();
+    cfg.agentName = name;
+    cfg.bio = "Autonomy-evolution E2E agent";
+    cfg.lore = "Created to validate the self-regulating cognitive loop";
+    cfg.adjective = "reflective";
+    return cfg;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// State::updateGoalStatus - lifecycle mutation API (structure-preserving)
+// ---------------------------------------------------------------------------
+
+class StateGoalLifecycleTest : public ::testing::Test {};
+
+TEST_F(StateGoalLifecycleTest, UpdatesStatusOfExistingGoal) {
+    State state(makeConfig("State-Goal"));
+    const Timestamp now = std::chrono::system_clock::now();
+    StateGoal goal{generateUUID(), "investigate workspace", "pending", now, now};
+    state.addGoal(goal);
+
+    ASSERT_EQ(state.getGoals().size(), 1u);
+    EXPECT_EQ(state.getGoals()[0].status, "pending");
+
+    const bool updated = state.updateGoalStatus(goal.id, "active");
+    EXPECT_TRUE(updated);
+    EXPECT_EQ(state.getGoals()[0].status, "active");
+}
+
+TEST_F(StateGoalLifecycleTest, ReturnsFalseForUnknownGoal) {
+    State state(makeConfig("State-Goal-Missing"));
+    const Timestamp now = std::chrono::system_clock::now();
+    state.addGoal(StateGoal{generateUUID(), "g", "pending", now, now});
+
+    EXPECT_FALSE(state.updateGoalStatus("nonexistent-id", "completed"));
+    // Existing goal must remain untouched.
+    EXPECT_EQ(state.getGoals()[0].status, "pending");
+}
+
+TEST_F(StateGoalLifecycleTest, RefreshesUpdatedTimestamp) {
+    State state(makeConfig("State-Goal-Timestamp"));
+    const Timestamp past =
+        std::chrono::system_clock::now() - std::chrono::hours(1);
+    StateGoal goal{generateUUID(), "g", "active", past, past};
+    state.addGoal(goal);
+
+    EXPECT_TRUE(state.updateGoalStatus(goal.id, "completed"));
+    EXPECT_GT(state.getGoals()[0].updatedAt, past);
+    EXPECT_EQ(state.getGoals()[0].status, "completed");
+}
+
+// ---------------------------------------------------------------------------
+// Reflection phase
+// ---------------------------------------------------------------------------
+
+class ReflectionLoopTest : public ::testing::Test {};
+
+TEST_F(ReflectionLoopTest, ReflectionRunsEveryCycle) {
+    AutonomousStarter agent(makeConfig("Reflective-Agent"));
+    agent.start();
+
+    EXPECT_EQ(agent.getReflectionCount(), 0u);
+
+    for (std::size_t i = 1; i <= 4; ++i) {
+        agent.runCognitiveCycleOnce();
+        // One reflection per cognitive cycle.
+        EXPECT_EQ(agent.getReflectionCount(), i);
+        // Reflection conclusion must be populated and reference a plan.
+        EXPECT_FALSE(agent.getLastReflection().empty());
+        EXPECT_NE(agent.getLastReflection().find("reflection"), std::string::npos);
+    }
+
+    agent.stop();
+}
+
+TEST_F(ReflectionLoopTest, ReflectionRecordsActionOutcome) {
+    AutonomousStarter agent(makeConfig("Outcome-Agent"));
+    agent.start();
+    agent.runCognitiveCycleOnce();
+
+    // The reflection text must report either success or failure of the action,
+    // and the boolean accessor must agree with the recorded reflection.
+    const std::string reflection = agent.getLastReflection();
+    const bool succeeded = agent.getLastActionSucceeded();
+    if (succeeded) {
+        EXPECT_NE(reflection.find("succeeded"), std::string::npos);
+    } else {
+        EXPECT_NE(reflection.find("failed"), std::string::npos);
+    }
+
+    agent.stop();
+}
+
+// ---------------------------------------------------------------------------
+// Attention-weighted goal selection
+// ---------------------------------------------------------------------------
+
+class AttentionFocusTest : public ::testing::Test {};
+
+TEST_F(AttentionFocusTest, FocusesOnAnOpenGoal) {
+    AutonomousStarter agent(makeConfig("Focus-Agent"));
+    agent.start();
+
+    // Before reasoning there is no committed focus.
+    EXPECT_TRUE(agent.getFocusedGoalId().empty());
+
+    agent.runCognitiveCycleOnce();
+
+    // After a cycle the agent must have committed to a concrete goal id, and
+    // that id must correspond to one of the seeded goals.
+    const UUID focused = agent.getFocusedGoalId();
+    EXPECT_FALSE(focused.empty());
+
+    bool matchesSeededGoal = false;
+    for (const auto& goal : agent.getState().getGoals()) {
+        if (goal.id == focused) {
+            matchesSeededGoal = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(matchesSeededGoal);
+
+    agent.stop();
+}
+
+TEST_F(AttentionFocusTest, FocusRemainsValidAcrossCycles) {
+    AutonomousStarter agent(makeConfig("Focus-Stability"));
+    agent.start();
+
+    for (int i = 0; i < 6; ++i) {
+        agent.runCognitiveCycleOnce();
+        const UUID focused = agent.getFocusedGoalId();
+        EXPECT_FALSE(focused.empty());
+        bool valid = false;
+        for (const auto& goal : agent.getState().getGoals()) {
+            if (goal.id == focused) {
+                valid = true;
+                break;
+            }
+        }
+        EXPECT_TRUE(valid) << "focused goal id must always map to a real goal";
+    }
+
+    agent.stop();
+}
+
+// ---------------------------------------------------------------------------
+// Plan-success feedback learning
+// ---------------------------------------------------------------------------
+
+class PlanFeedbackTest : public ::testing::Test {};
+
+TEST_F(PlanFeedbackTest, PlanSuccessRatioIsBounded) {
+    AutonomousStarter agent(makeConfig("Feedback-Agent"));
+    agent.start();
+
+    // Run enough cycles to accumulate plan statistics.
+    for (int i = 0; i < 8; ++i) {
+        agent.runCognitiveCycleOnce();
+    }
+
+    // The plan the agent most recently committed to must have a well-defined,
+    // bounded success ratio in [0,1].
+    const std::string plan = agent.getLastPlan();
+    EXPECT_FALSE(plan.empty());
+    const double ratio = agent.getPlanSuccessRatio(plan);
+    EXPECT_GE(ratio, 0.0);
+    EXPECT_LE(ratio, 1.0);
+
+    // Unknown plans must report 0.0 rather than crash.
+    EXPECT_DOUBLE_EQ(agent.getPlanSuccessRatio("a plan never executed"), 0.0);
+
+    agent.stop();
+}
+
+TEST_F(PlanFeedbackTest, SuccessfulPlansAccumulatePositiveRatio) {
+    AutonomousStarter agent(makeConfig("Feedback-Positive"));
+    agent.start();
+
+    // Safe filesystem-introspection plans should generally succeed in the
+    // sandbox, so after several cycles at least one executed plan must have a
+    // strictly positive success ratio (proving feedback is actually recorded).
+    std::vector<std::string> seenPlans;
+    for (int i = 0; i < 10; ++i) {
+        agent.runCognitiveCycleOnce();
+        seenPlans.push_back(agent.getLastPlan());
+    }
+
+    bool anyPositive = false;
+    for (const auto& plan : seenPlans) {
+        if (agent.getPlanSuccessRatio(plan) > 0.0) {
+            anyPositive = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(anyPositive)
+        << "feedback learning must record at least one successful plan outcome";
+
+    agent.stop();
+}
+
+// ---------------------------------------------------------------------------
+// Goal lifecycle progression driven by autonomy
+// ---------------------------------------------------------------------------
+
+class GoalLifecycleProgressionTest : public ::testing::Test {};
+
+TEST_F(GoalLifecycleProgressionTest, GoalsProgressTowardCompletion) {
+    AutonomousStarter agent(makeConfig("Lifecycle-Agent"));
+    agent.start();
+
+    auto countByStatus = [&](const std::string& status) {
+        std::size_t n = 0;
+        for (const auto& goal : agent.getState().getGoals()) {
+            std::string s = goal.status;
+            for (auto& c : s) c = static_cast<char>(::tolower(c));
+            if (s == status) ++n;
+        }
+        return n;
+    };
+
+    const std::size_t initialPending = countByStatus("pending");
+    EXPECT_GE(agent.getState().getGoals().size(), 1u);
+
+    // Drive many cycles so the agent can transition goals through their
+    // lifecycle as plans prove reliable.
+    for (int i = 0; i < 20; ++i) {
+        agent.runCognitiveCycleOnce();
+    }
+
+    // The autonomy loop must make measurable progress: either some pending goal
+    // became active/completed, or a goal reached the completed state.
+    const std::size_t finalPending = countByStatus("pending");
+    const std::size_t finalCompleted = countByStatus("completed");
+    const std::size_t finalActive = countByStatus("active");
+
+    EXPECT_TRUE(finalPending < initialPending || finalCompleted > 0 ||
+                finalActive > 0)
+        << "goal lifecycle must advance under sustained autonomy";
+
+    agent.stop();
+}
+
+// ---------------------------------------------------------------------------
+// Full-loop coherence
+// ---------------------------------------------------------------------------
+
+class FullLoopCoherenceTest : public ::testing::Test {};
+
+TEST_F(FullLoopCoherenceTest, AllFourPhasesStayConsistent) {
+    AutonomousStarter agent(makeConfig("Coherence-E2E"));
+    agent.start();
+
+    const int kCycles = 12;
+    for (int i = 0; i < kCycles; ++i) {
+        agent.runCognitiveCycleOnce();
+
+        // Each cycle must leave the agent in a fully consistent state.
+        EXPECT_FALSE(agent.getLastObservationSummary().empty());
+        EXPECT_FALSE(agent.getLastPlan().empty());
+        EXPECT_FALSE(agent.getLastReflection().empty());
+    }
+
+    // Cycle, action, and reflection counters must all advance in lock-step:
+    // exactly one perception, one action, and one reflection per cycle.
+    EXPECT_EQ(agent.getCognitiveCycleCount(),
+              static_cast<std::size_t>(kCycles));
+    EXPECT_EQ(agent.getActionCount(), static_cast<std::size_t>(kCycles));
+    EXPECT_EQ(agent.getReflectionCount(), static_cast<std::size_t>(kCycles));
+
+    // Memory must accumulate strictly. Reasoning, action, and reflection each
+    // append at least one named cycle memory, so the recent-message stream must
+    // grow by at least two entries per cycle (a conservative lower bound that
+    // holds even if individual shell observations are coalesced).
+    EXPECT_GE(agent.getState().getRecentMessages().size(),
+              static_cast<std::size_t>(kCycles) * 2);
+
+    agent.stop();
+}
+
+TEST_F(FullLoopCoherenceTest, SelfCheckStillPassesAfterEvolution) {
+    // The optimized loop must not regress the package self-check.
+    EXPECT_TRUE(autonomous_starter_self_check());
+}

--- a/include/elizaos/autonomous_starter.hpp
+++ b/include/elizaos/autonomous_starter.hpp
@@ -12,11 +12,14 @@
 #include "core.hpp"
 #include "agentloop.hpp"
 #include "agentshell.hpp"
+#include "attention.hpp"
 
 #include <atomic>
 #include <chrono>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace elizaos {
 
@@ -57,11 +60,28 @@ public:
 
     // Deterministic single-cycle autonomy controls for tests, supervisors, and
     // embedding runtimes that need bounded observe-reason-act stepping.
+    // Each cycle now runs the full perceive -> reason -> act -> reflect loop.
     std::size_t runCognitiveCycleOnce();
     std::size_t getCognitiveCycleCount() const { return cognitiveCycle_; }
     std::size_t getActionCount() const { return actionCounter_; }
     const std::string& getLastObservationSummary() const { return lastObservationSummary_; }
     const std::string& getLastPlan() const { return lastPlan_; }
+
+    // Reflection / learning surface. After each cycle the agent records whether
+    // the executed action succeeded and the reflective conclusion it drew.
+    const std::string& getLastReflection() const { return lastReflection_; }
+    std::size_t getReflectionCount() const { return reflectionCount_; }
+    bool getLastActionSucceeded() const { return lastActionSucceeded_; }
+
+    // Attention-weighted autonomy introspection. Returns the goal id the agent
+    // is currently focused on (highest attention composite score among open
+    // goals), or an empty string when no goals exist.
+    UUID getFocusedGoalId() const { return focusedGoalId_; }
+
+    // Returns the success ratio (0.0-1.0) of every plan label the agent has
+    // executed so far. Used by supervisors and tests to confirm that the agent
+    // adapts plan selection based on accumulated outcome feedback.
+    double getPlanSuccessRatio(const std::string& plan) const;
 
     // State access
     State& getState() { return state_; }
@@ -77,10 +97,25 @@ private:
     std::string selectGoalContext() const;
     std::string buildActionCommandForPlan(const std::string& plan) const;
 
+    // Attention-weighted goal selection. Seeds/refreshes attention values for
+    // every open goal and returns the highest-scoring open goal, falling back
+    // to the most recent goal when none are open.
+    const StateGoal* selectFocusGoal();
+    void refreshGoalAttention();
+
+    // Outcome-based plan adaptation. Records the success/failure of a plan and
+    // biases future plan selection toward historically successful plans.
+    void recordPlanOutcome(const std::string& plan, bool success);
+    double planBias(const std::string& plan) const;
+
+    // Goal lifecycle transition driven by accomplished plans.
+    void advanceGoalLifecycle(const std::string& plan, bool actionSucceeded);
+
     // Internal cognitive steps
     std::shared_ptr<void> perceptionStep(std::shared_ptr<void> input);
     std::shared_ptr<void> reasoningStep(std::shared_ptr<void> input);
     std::shared_ptr<void> actionStep(std::shared_ptr<void> input);
+    std::shared_ptr<void> reflectionStep(std::shared_ptr<void> input);
 
     // Memory helpers
     void appendMemory(const std::string& content);
@@ -120,6 +155,21 @@ private:
     std::size_t actionCounter_{0};
     std::string lastObservationSummary_;
     std::string lastPlan_;
+
+    // Reflection / learning state.
+    std::string lastReflection_;
+    std::size_t reflectionCount_{0};
+    bool lastActionSucceeded_{false};
+    std::string lastActionCommand_;
+    std::string lastActionOutput_;
+
+    // Attention-weighted goal selection state.
+    AttentionAllocator goalAttention_;
+    UUID focusedGoalId_;
+
+    // Per-plan outcome feedback: plan label -> (successes, attempts).
+    struct PlanStats { std::size_t successes{0}; std::size_t attempts{0}; };
+    std::unordered_map<std::string, PlanStats> planStats_;
 };
 
 std::shared_ptr<AutonomousStarter> createAutolizaAgent();

--- a/include/elizaos/core.hpp
+++ b/include/elizaos/core.hpp
@@ -344,6 +344,11 @@ public:
     void addActor(const Actor& actor);
     void addGoal(const StateGoal& goal);
     void addRecentMessage(std::shared_ptr<Memory> memory);
+
+    // Goal lifecycle mutation (structure-preserving extension). Updates the
+    // status (and updatedAt timestamp) of the goal identified by goalId.
+    // Returns true if a matching goal was found and updated.
+    bool updateGoalStatus(const UUID& goalId, const std::string& status);
     
     const std::vector<Actor>& getActors() const { return actors_; }
     const std::vector<StateGoal>& getGoals() const { return goals_; }


### PR DESCRIPTION
## Summary
Ports the **AutonomousStarter self-regulation optimization** to bring this repo to functional parity with the hurdcog working tree. Converts the open-loop `perceive -> reason -> act` cycle into a closed-loop `perceive -> reason -> act -> reflect` cycle.

## Changes
- **`State::updateGoalStatus(id, status)`** — structure-preserving goal lifecycle mutation.
- **Attention-weighted goal focus** via the existing `AttentionAllocator` (composite-score selection).
- **Outcome-based plan feedback** — per-plan `(successes, attempts)` with an optimistic `0.5` prior; `getPlanSuccessRatio()`.
- **Reflection phase** — `reflectionStep()` records outcome, applies feedback + lifecycle, writes a reflective memory.
- **CMake** — links `elizaos-agentmemory` into the autonomy library, demo, and test targets.

## Tests
New `real_autonomy_evolution_test` (6 suites / 12 cases). 

**Canonical root build green: 82/82 tests pass** (`cmake ..` from repo root — note the build MUST be configured from the repository root, not `cpp/`).