### PR TITLE
autonomy: closed-loop goal progression (KSM living center, parity)

### DIFF
--- a/cpp/packages/core/core/src/core.cpp
+++ b/cpp/packages/core/core/src/core.cpp
@@ -113,6 +113,17 @@ void State::addGoal(const Goal& goal) {
     goals_.push_back(goal);
 }
 
+bool State::updateGoalStatus(const UUID& goalId, const std::string& status) {
+    for (auto& goal : goals_) {
+        if (goal.id == goalId) {
+            goal.status = status;
+            goal.updatedAt = std::chrono::system_clock::now();
+            return true;
+        }
+    }
+    return false;
+}
+
 void State::addRecentMessage(std::shared_ptr<Memory> memory) {
     recentMessages_.push_back(memory);
     

--- a/cpp/packages/integration/autonomous_starter/src/autonomous_starter.cpp
+++ b/cpp/packages/integration/autonomous_starter/src/autonomous_starter.cpp
@@ -282,14 +282,181 @@ std::string AutonomousStarter::selectGoalContext() const {
         return status;
     };
 
-    for (const auto& goal : goals) {
-        const auto status = normalizeStatus(goal.status);
-        if (status == "active" || status == "in_progress" || status == "pending") {
-            return goal.description.empty() ? "continue open autonomy goal" : goal.description;
+    // Prefer the currently pursued goal so perception, reasoning, and action all
+    // converge on the same intent within a cycle.
+    if (!activeGoalId_.empty()) {
+        for (const auto& goal : goals) {
+            if (goal.id == activeGoalId_) {
+                const auto status = normalizeStatus(goal.status);
+                if (status == "active" || status == "in_progress" || status == "pending") {
+                    return goal.description.empty() ? "continue open autonomy goal" : goal.description;
+                }
+            }
+        }
+    }
+
+    // Priority order: active > in_progress > pending.
+    for (const char* wanted : {"active", "in_progress", "pending"}) {
+        for (const auto& goal : goals) {
+            if (normalizeStatus(goal.status) == wanted) {
+                return goal.description.empty() ? "continue open autonomy goal" : goal.description;
+            }
         }
     }
 
     return goals.back().description.empty() ? "review completed autonomy context" : goals.back().description;
+}
+
+const StateGoal* AutonomousStarter::selectActiveGoal() {
+    const auto& goals = state_.getGoals();
+    auto normalizeStatus = [](std::string status) {
+        std::transform(status.begin(), status.end(), status.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return status;
+    };
+
+    // Promote the first pending goal to active when no active goal exists, so
+    // the agent always has exactly one goal in flight (single-tasking autonomy).
+    const StateGoal* active = nullptr;
+    const StateGoal* firstPending = nullptr;
+    for (const auto& goal : goals) {
+        const auto status = normalizeStatus(goal.status);
+        if ((status == "active" || status == "in_progress") && active == nullptr) {
+            active = &goal;
+        } else if (status == "pending" && firstPending == nullptr) {
+            firstPending = &goal;
+        }
+    }
+
+    if (active == nullptr && firstPending != nullptr) {
+        state_.updateGoalStatus(firstPending->id, "active");
+        for (const auto& goal : state_.getGoals()) {
+            if (goal.id == firstPending->id) {
+                active = &goal;
+                break;
+            }
+        }
+    }
+
+    if (active != nullptr) {
+        activeGoalId_ = active->id;
+    } else {
+        activeGoalId_ = "";
+    }
+    return active;
+}
+
+bool AutonomousStarter::planSatisfiesGoal(const StateGoal& goal,
+                                          const std::string& plan,
+                                          const ShellCommandResult& result) const {
+    // A goal is only satisfied by a successful action whose plan is topically
+    // aligned with the goal. Failed commands never satisfy a goal, so the agent
+    // will keep working (or escalate via the stagnation guard) until it produces
+    // real evidence. This is the behavioral consequence that makes the goal
+    // center "living" rather than a decorative status field.
+    if (!result.success) {
+        return false;
+    }
+
+    const std::string goalText = toLowerAscii(goal.description);
+    const std::string planText = toLowerAscii(plan);
+
+    auto mentions = [](const std::string& text, std::initializer_list<const char*> needles) {
+        for (const char* needle : needles) {
+            if (text.find(needle) != std::string::npos) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    if (mentions(goalText, {"situational awareness", "workspace", "awareness"})) {
+        return mentions(planText, {"situational awareness", "workspace", "awareness", "pwd", "directory"});
+    }
+    if (mentions(goalText, {"project structure", "c++", "source", "cmake", "code actions"})) {
+        return mentions(planText, {"project structure", "source", "c++", "cmake", "repository source"});
+    }
+    if (mentions(goalText, {"test", "validation", "self-audit", "audit"})) {
+        return mentions(planText, {"test", "validation", "self-audit", "audit"});
+    }
+    if (mentions(goalText, {"runtime", "system", "kernel", "identity"})) {
+        return mentions(planText, {"runtime", "system", "kernel", "identity"});
+    }
+
+    // Generic exploration goals are satisfied by any successful action.
+    return true;
+}
+
+void AutonomousStarter::seedAdaptiveGoal() {
+    const Timestamp now = std::chrono::system_clock::now();
+    static const std::array<const char*, 3> rotations = {{
+        "Sample repository source files to deepen project understanding",
+        "Self-audit test and validation surfaces for autonomy health",
+        "Inspect system identity and runtime context for situational grounding"
+    }};
+    const std::string description = rotations[adaptiveGoalCounter_ % rotations.size()];
+    ++adaptiveGoalCounter_;
+    state_.addGoal(StateGoal{
+        generateUUID(),
+        description,
+        "pending",
+        now,
+        now
+    });
+    appendMemory("Adaptive goal seeded: " + description +
+                 " (all prior goals satisfied; autonomy continues exploring).");
+}
+
+void AutonomousStarter::evaluateGoalProgress(const std::string& plan,
+                                             const std::string& command,
+                                             const ShellCommandResult& result) {
+    (void)command;
+
+    // Mark the active goal completed when the successful action provides aligned
+    // evidence, then promote the next pending goal.
+    if (!activeGoalId_.empty()) {
+        const StateGoal* activeGoal = nullptr;
+        for (const auto& goal : state_.getGoals()) {
+            if (goal.id == activeGoalId_) {
+                activeGoal = &goal;
+                break;
+            }
+        }
+        if (activeGoal != nullptr && planSatisfiesGoal(*activeGoal, plan, result)) {
+            const std::string completedDescription = activeGoal->description;
+            state_.updateGoalStatus(activeGoalId_, "completed");
+            appendMemory("Goal completed: " + completedDescription +
+                         " (satisfied by plan='" + plan + "').");
+            activeGoalId_ = "";
+        }
+    }
+
+    // If every goal is now complete, seed a fresh adaptive goal so the agent
+    // never dead-ends into a no-open-goal idle loop.
+    if (getOpenGoalCount() == 0) {
+        seedAdaptiveGoal();
+    }
+}
+
+std::size_t AutonomousStarter::getOpenGoalCount() const {
+    std::size_t open = 0;
+    for (const auto& goal : state_.getGoals()) {
+        std::string status = toLowerAscii(goal.status);
+        if (status == "active" || status == "in_progress" || status == "pending") {
+            ++open;
+        }
+    }
+    return open;
+}
+
+std::size_t AutonomousStarter::getCompletedGoalCount() const {
+    std::size_t completed = 0;
+    for (const auto& goal : state_.getGoals()) {
+        if (toLowerAscii(goal.status) == "completed") {
+            ++completed;
+        }
+    }
+    return completed;
 }
 
 std::string AutonomousStarter::buildActionCommandForPlan(const std::string& plan) const {
@@ -541,6 +708,11 @@ std::size_t AutonomousStarter::runCognitiveCycleOnce() {
 std::shared_ptr<void> AutonomousStarter::perceptionStep(std::shared_ptr<void> input) {
     ++cognitiveCycle_;
 
+    // Resolve which goal we are pursuing this cycle (promotes a pending goal to
+    // active if nothing is active), so the whole observe-reason-act pass is
+    // anchored to a single concrete intent.
+    selectActiveGoal();
+
     const auto pwd = executeShellCommand("pwd");
     const auto listing = executeShellCommand("ls -1 | head -20");
 
@@ -573,20 +745,31 @@ std::shared_ptr<void> AutonomousStarter::reasoningStep(std::shared_ptr<void> inp
     std::transform(normalizedGoal.begin(), normalizedGoal.end(), normalizedGoal.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
 
-    if (normalizedGoal.find("test") != std::string::npos ||
+    // Plan selection is goal-first: the plan must serve the goal the agent is
+    // actively pursuing, otherwise action evidence can never satisfy that goal
+    // and the closed loop cannot converge. Topic precedence is keyed on the
+    // active goal's description, with environmental hints used only as a
+    // tie-breaker for goals that are themselves about project structure.
+    if (normalizedGoal.find("situational awareness") != std::string::npos ||
+        normalizedGoal.find("workspace") != std::string::npos ||
+        normalizedGoal.find("awareness") != std::string::npos) {
+        lastPlan_ = "establish situational awareness with pwd and directory inspection";
+    } else if (normalizedGoal.find("test") != std::string::npos ||
         normalizedGoal.find("validation") != std::string::npos ||
         normalizedGoal.find("self-audit") != std::string::npos ||
         normalizedGoal.find("audit") != std::string::npos) {
         lastPlan_ = "run autonomy self-audit by inspecting tests and validation coverage";
     } else if (normalizedGoal.find("c++") != std::string::npos ||
                normalizedGoal.find("project structure") != std::string::npos ||
-               lastObservationSummary_.find("CMakeLists.txt") != std::string::npos) {
+               normalizedGoal.find("source") != std::string::npos ||
+               normalizedGoal.find("code actions") != std::string::npos) {
         lastPlan_ = "inspect C++ project structure with targeted source discovery";
     } else if (normalizedGoal.find("runtime") != std::string::npos ||
-               normalizedGoal.find("system") != std::string::npos) {
+               normalizedGoal.find("system") != std::string::npos ||
+               normalizedGoal.find("identity") != std::string::npos ||
+               normalizedGoal.find("kernel") != std::string::npos) {
         lastPlan_ = "inspect system identity and runtime context";
-    } else if (memoryCount < 5 || normalizedGoal.find("situational awareness") != std::string::npos ||
-               normalizedGoal.find("workspace") != std::string::npos) {
+    } else if (memoryCount < 5) {
         lastPlan_ = "establish situational awareness with pwd and directory inspection";
     } else if (actionCounter_ % 3 == 0) {
         lastPlan_ = "sample repository source files";
@@ -595,6 +778,35 @@ std::shared_ptr<void> AutonomousStarter::reasoningStep(std::shared_ptr<void> inp
     } else {
         lastPlan_ = "maintain lightweight environmental awareness";
     }
+
+    // Stagnation guard: if reasoning keeps producing the same plan, the agent is
+    // stuck. Count consecutive repeats and, once a threshold is crossed, escalate
+    // to a deliberately different plan so autonomy explores instead of looping.
+    if (lastPlan_ == previousPlan_) {
+        ++stagnationCounter_;
+    } else {
+        stagnationCounter_ = 0;
+    }
+    if (stagnationCounter_ >= 2) {
+        static const std::array<const char*, 4> escalationPlans = {{
+            "sample repository source files",
+            "run autonomy self-audit by inspecting tests and validation coverage",
+            "inspect system identity and runtime context",
+            "establish situational awareness with pwd and directory inspection"
+        }};
+        std::string escalated = lastPlan_;
+        for (const char* candidate : escalationPlans) {
+            if (candidate != lastPlan_) {
+                escalated = candidate;
+                break;
+            }
+        }
+        appendMemory("Stagnation detected after " + std::to_string(stagnationCounter_) +
+                     " repeats of plan '" + lastPlan_ + "'; escalating to '" + escalated + "'.");
+        lastPlan_ = escalated;
+        stagnationCounter_ = 0;
+    }
+    previousPlan_ = lastPlan_;
 
     appendMemory("Cycle " + std::to_string(cognitiveCycle_) +
                  " reasoning: goal = " + goalContext +
@@ -614,6 +826,11 @@ std::shared_ptr<void> AutonomousStarter::actionStep(std::shared_ptr<void> input)
                  " action: command='" + command + "', success=" +
                  std::string(result.success ? "true" : "false") +
                  ", exitCode=" + std::to_string(result.exitCode) + ".");
+
+    // Close the loop: feed the action outcome back into goal state so successful,
+    // aligned actions complete the active goal and promote the next one. This is
+    // what turns the goal list from a static seed into a converging drive.
+    evaluateGoalProgress(lastPlan_, command, result);
     return input;
 }
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -604,3 +604,17 @@ add_real_test(real_autonomy_optimizer_test src/test_autonomy_optimizer.cpp)
 if(TARGET real_autonomy_optimizer_test)
     list(APPEND ELIZAOS_KSM_CANONICAL_TEST_TARGETS real_autonomy_optimizer_test)
 endif()
+
+# ============================================================================
+# Closed-loop goal-progression autonomy regression suite (parity with hurdcog).
+# Locks in the structure-preserving upgrade that turns the autonomy goal center
+# from an open-loop seed into a converging, evidence-driven drive
+# (State::updateGoalStatus, active-goal selection, completion-on-evidence,
+# adaptive re-seeding, stagnation guard).
+# ============================================================================
+add_real_test(real_closed_loop_autonomy_test src/test_closed_loop_autonomy.cpp)
+if(TARGET real_closed_loop_autonomy_test)
+    list(APPEND ELIZAOS_KSM_CANONICAL_TEST_TARGETS real_closed_loop_autonomy_test)
+    add_dependencies(ksm_canonical_tests real_closed_loop_autonomy_test)
+    set_tests_properties(real_closed_loop_autonomy_test PROPERTIES LABELS "ksm;canonical")
+endif()

--- a/cpp/tests/src/test_closed_loop_autonomy.cpp
+++ b/cpp/tests/src/test_closed_loop_autonomy.cpp
@@ -1,0 +1,209 @@
+// test_closed_loop_autonomy.cpp
+//
+// Comprehensive end-to-end tests for the closed-loop goal-progression autonomy
+// added to AutonomousStarter and the supporting State::updateGoalStatus API.
+//
+// These tests prove that goals are no longer a static decorative seed: the agent
+// advances pending -> active -> completed based on real action evidence, never
+// dead-ends (adaptive goal re-seeding), and escapes plan stagnation. Every
+// assertion exercises the real compiled canonical API -- no mocks, no stubs.
+#include <gtest/gtest.h>
+
+#include "elizaos/core.hpp"
+#include "elizaos/autonomous_starter.hpp"
+
+#include <chrono>
+#include <string>
+
+using namespace elizaos;
+
+namespace {
+
+AgentConfig makeConfig(const std::string& name = "ClosedLoop-Agent") {
+    AgentConfig cfg;
+    cfg.agentId = generateUUID();
+    cfg.agentName = name;
+    cfg.bio = "Closed-loop goal-progression autonomy test agent";
+    cfg.lore = "Created to validate converging goal-driven autonomy";
+    cfg.adjective = "deliberate";
+    return cfg;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// State::updateGoalStatus -- the minimal canonical surface that makes the goal
+// center mutable and therefore alive.
+// ---------------------------------------------------------------------------
+
+TEST(StateGoalLifecycleTest, UpdateGoalStatusTransitionsExistingGoal) {
+    State state(makeConfig());
+    const Timestamp now = std::chrono::system_clock::now();
+    const UUID goalId = generateUUID();
+    state.addGoal(StateGoal{goalId, "Investigate workspace", "pending", now, now});
+
+    ASSERT_EQ(state.getGoals().size(), 1u);
+    EXPECT_EQ(state.getGoals().front().status, "pending");
+
+    const Timestamp before = state.getGoals().front().updatedAt;
+    const bool updated = state.updateGoalStatus(goalId, "active");
+
+    EXPECT_TRUE(updated);
+    EXPECT_EQ(state.getGoals().front().status, "active");
+    // updatedAt must advance (monotonic, never regress).
+    EXPECT_GE(state.getGoals().front().updatedAt, before);
+}
+
+TEST(StateGoalLifecycleTest, UpdateGoalStatusReturnsFalseForUnknownGoal) {
+    State state(makeConfig());
+    const Timestamp now = std::chrono::system_clock::now();
+    state.addGoal(StateGoal{generateUUID(), "Known goal", "pending", now, now});
+
+    EXPECT_FALSE(state.updateGoalStatus(generateUUID(), "completed"));
+    // The existing goal must be untouched.
+    EXPECT_EQ(state.getGoals().front().status, "pending");
+}
+
+TEST(StateGoalLifecycleTest, UpdateGoalStatusOnlyAffectsMatchingGoal) {
+    State state(makeConfig());
+    const Timestamp now = std::chrono::system_clock::now();
+    const UUID first = generateUUID();
+    const UUID second = generateUUID();
+    state.addGoal(StateGoal{first, "First", "pending", now, now});
+    state.addGoal(StateGoal{second, "Second", "pending", now, now});
+
+    EXPECT_TRUE(state.updateGoalStatus(second, "completed"));
+    EXPECT_EQ(state.getGoals()[0].status, "pending");
+    EXPECT_EQ(state.getGoals()[1].status, "completed");
+}
+
+// ---------------------------------------------------------------------------
+// AutonomousStarter closed-loop goal progression.
+// ---------------------------------------------------------------------------
+
+class ClosedLoopAutonomyTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        agent_ = std::make_shared<AutonomousStarter>(makeConfig());
+        agent_->start();
+    }
+
+    void TearDown() override {
+        if (agent_) {
+            agent_->stop();
+        }
+    }
+
+    std::shared_ptr<AutonomousStarter> agent_;
+};
+
+TEST_F(ClosedLoopAutonomyTest, StartSeedsCoreGoalsWithOpenWork) {
+    // start() must seed core autonomy goals so the agent has something to drive.
+    EXPECT_GE(agent_->getState().getGoals().size(), 1u);
+    EXPECT_GE(agent_->getOpenGoalCount(), 1u);
+    EXPECT_EQ(agent_->getCompletedGoalCount(), 0u);
+}
+
+TEST_F(ClosedLoopAutonomyTest, FirstCycleSelectsAndPursuesAnActiveGoal) {
+    agent_->runCognitiveCycleOnce();
+    // After a cycle the agent must have pursued a concrete goal: a plan was
+    // formed and at least one action executed. The active goal id may already be
+    // cleared if the goal completed within the cycle (the convergent fast path),
+    // so success is evidenced by progress, not by a still-pending pursuit.
+    EXPECT_FALSE(agent_->getLastPlan().empty());
+    EXPECT_GE(agent_->getActionCount(), 1u);
+    // Either a goal is still being pursued, or at least one goal has completed.
+    EXPECT_TRUE(!agent_->getActiveGoalId().empty() ||
+                agent_->getCompletedGoalCount() >= 1u);
+}
+
+TEST_F(ClosedLoopAutonomyTest, GoalsConvergeToCompletionOverMultipleCycles) {
+    const std::size_t initialOpen = agent_->getOpenGoalCount();
+    ASSERT_GE(initialOpen, 1u);
+
+    // Run enough bounded cycles to drive the seeded goals to completion.
+    for (int i = 0; i < 12; ++i) {
+        agent_->runCognitiveCycleOnce();
+    }
+
+    // The agent must have completed at least the originally seeded goals -- this
+    // is the core proof that goal state is closed-loop, not open-loop.
+    EXPECT_GE(agent_->getCompletedGoalCount(), initialOpen);
+    EXPECT_EQ(agent_->getCognitiveCycleCount(), 12u);
+}
+
+TEST_F(ClosedLoopAutonomyTest, AutonomyNeverDeadEndsOnOpenGoals) {
+    // After many cycles there must always remain at least one open goal to
+    // pursue (adaptive re-seeding), so the agent never idles with nothing to do.
+    for (int i = 0; i < 15; ++i) {
+        agent_->runCognitiveCycleOnce();
+    }
+    EXPECT_GE(agent_->getOpenGoalCount(), 1u);
+}
+
+TEST_F(ClosedLoopAutonomyTest, AdaptiveGoalsAreSeededAfterCompletion) {
+    const std::size_t seededAtStart = agent_->getState().getGoals().size();
+    for (int i = 0; i < 15; ++i) {
+        agent_->runCognitiveCycleOnce();
+    }
+    // Completing the seed goals should have grown the goal list with adaptive
+    // exploration goals.
+    EXPECT_GT(agent_->getState().getGoals().size(), seededAtStart);
+}
+
+TEST_F(ClosedLoopAutonomyTest, CompletedGoalsCarryEvidenceInMemory) {
+    for (int i = 0; i < 12; ++i) {
+        agent_->runCognitiveCycleOnce();
+    }
+    // The memory stream must record at least one explicit goal completion,
+    // proving the loop closed on observed evidence rather than a timer.
+    bool foundCompletion = false;
+    for (const auto& memory : agent_->getState().getRecentMessages()) {
+        if (memory && memory->getContent().find("Goal completed:") != std::string::npos) {
+            foundCompletion = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(foundCompletion);
+}
+
+TEST_F(ClosedLoopAutonomyTest, StagnationGuardKeepsStagnationBounded) {
+    // Across many cycles the stagnation counter must stay bounded (the guard
+    // resets it on escalation), proving the agent cannot lock into one plan.
+    for (int i = 0; i < 20; ++i) {
+        agent_->runCognitiveCycleOnce();
+        EXPECT_LE(agent_->getStagnationCounter(), 2u);
+    }
+}
+
+TEST_F(ClosedLoopAutonomyTest, ActiveGoalIsAlwaysAValidOpenGoalDuringPursuit) {
+    for (int i = 0; i < 8; ++i) {
+        agent_->runCognitiveCycleOnce();
+        const UUID active = agent_->getActiveGoalId();
+        if (active.empty()) {
+            continue;  // transient between completion and next promotion
+        }
+        bool matchesOpenGoal = false;
+        for (const auto& goal : agent_->getState().getGoals()) {
+            if (goal.id == active) {
+                EXPECT_NE(goal.status, "completed");
+                matchesOpenGoal = true;
+                break;
+            }
+        }
+        EXPECT_TRUE(matchesOpenGoal);
+    }
+}
+
+TEST_F(ClosedLoopAutonomyTest, ProgressIsDeterministicAcrossIdenticalRuns) {
+    // Two fresh agents driven the same number of cycles must reach the same
+    // completed-goal count -- progression is evidence-driven and deterministic.
+    auto secondAgent = std::make_shared<AutonomousStarter>(makeConfig("ClosedLoop-Agent-2"));
+    secondAgent->start();
+    for (int i = 0; i < 10; ++i) {
+        agent_->runCognitiveCycleOnce();
+        secondAgent->runCognitiveCycleOnce();
+    }
+    EXPECT_EQ(agent_->getCompletedGoalCount(), secondAgent->getCompletedGoalCount());
+    secondAgent->stop();
+}

--- a/include/elizaos/autonomous_starter.hpp
+++ b/include/elizaos/autonomous_starter.hpp
@@ -63,6 +63,17 @@ public:
     const std::string& getLastObservationSummary() const { return lastObservationSummary_; }
     const std::string& getLastPlan() const { return lastPlan_; }
 
+    // Closed-loop goal-progression introspection. These expose the convergence
+    // signals an autonomy supervisor needs: how many seeded goals are still open
+    // (pending/active/in_progress) versus completed, the id of the goal the agent
+    // is currently pursuing, and how many consecutive cycles produced the same
+    // plan (a stagnation signal). A healthy autonomous agent drives open goals to
+    // completion rather than looping a single plan indefinitely.
+    std::size_t getOpenGoalCount() const;
+    std::size_t getCompletedGoalCount() const;
+    const UUID& getActiveGoalId() const { return activeGoalId_; }
+    std::size_t getStagnationCounter() const { return stagnationCounter_; }
+
     // State access
     State& getState() { return state_; }
     const State& getState() const { return state_; }
@@ -76,6 +87,22 @@ private:
     void ensureCoreAutonomyGoals();
     std::string selectGoalContext() const;
     std::string buildActionCommandForPlan(const std::string& plan) const;
+
+    // Closed-loop goal-progression helpers.
+    // selectActiveGoal picks the highest-priority open goal (active >
+    // in_progress > pending) and records its id in activeGoalId_.
+    // evaluateGoalProgress inspects the latest action evidence and advances goal
+    // statuses: a satisfied active goal becomes "completed", and the next pending
+    // goal is promoted to "active". seedAdaptiveGoal injects a fresh exploration
+    // goal when every seeded goal is complete so autonomy never dead-ends.
+    const StateGoal* selectActiveGoal();
+    void evaluateGoalProgress(const std::string& plan,
+                              const std::string& command,
+                              const ShellCommandResult& result);
+    void seedAdaptiveGoal();
+    bool planSatisfiesGoal(const StateGoal& goal,
+                           const std::string& plan,
+                           const ShellCommandResult& result) const;
 
     // Internal cognitive steps
     std::shared_ptr<void> perceptionStep(std::shared_ptr<void> input);
@@ -120,6 +147,12 @@ private:
     std::size_t actionCounter_{0};
     std::string lastObservationSummary_;
     std::string lastPlan_;
+
+    // Closed-loop goal-progression state.
+    UUID activeGoalId_;
+    std::string previousPlan_;
+    std::size_t stagnationCounter_{0};
+    std::size_t adaptiveGoalCounter_{0};
 };
 
 std::shared_ptr<AutonomousStarter> createAutolizaAgent();

--- a/include/elizaos/core.hpp
+++ b/include/elizaos/core.hpp
@@ -344,7 +344,15 @@ public:
     void addActor(const Actor& actor);
     void addGoal(const StateGoal& goal);
     void addRecentMessage(std::shared_ptr<Memory> memory);
-    
+
+    // Goal lifecycle management.
+    // updateGoalStatus transitions an existing goal (matched by id) to a new
+    // status string and refreshes its updatedAt timestamp. It returns true when
+    // a goal was found and updated, false otherwise. This is the minimal,
+    // non-breaking surface required for closed-loop goal-driven autonomy where
+    // an agent advances pending->active->completed based on observed evidence.
+    bool updateGoalStatus(const UUID& goalId, const std::string& status);
+
     const std::vector<Actor>& getActors() const { return actors_; }
     const std::vector<StateGoal>& getGoals() const { return goals_; }
     const std::vector<std::shared_ptr<Memory>>& getRecentMessages() const { return recentMessages_; }


### PR DESCRIPTION
Closed-loop goal-progression autonomy upgrade (KSM living center).

## What
Turns the goal-driven autonomy center from an open-loop seed (goals never advanced, plan decoupled from active goal, no outcome feedback) into a converging, evidence-driven drive.

## Changes
- **core**: non-breaking `State::updateGoalStatus(id, status)` enabling pending->active->completed transitions without exposing the goal vector as mutable.
- **autonomous_starter**: single active goal per cycle (`selectActiveGoal`), goal-first plan selection, evidence-driven completion (`evaluateGoalProgress` + `planSatisfiesGoal`), adaptive re-seeding (`seedAdaptiveGoal`), and a stagnation guard.
- **introspection**: `getOpenGoalCount`, `getCompletedGoalCount`, `getActiveGoalId`, `getStagnationCounter`.
- **tests**: new `real_closed_loop_autonomy_test` (12 cases) wired into the KSM canonical target.

## Validation
Full KSM canonical suite **38/38 green** (was 37, +1 new suite). No regressions.