### PR TITLE
fix(build,parity): register cognitive_curriculum; complete otaku liquidity; backport planAgain + ms timestamps; 83/83

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ add_subdirectory(cpp/packages/applications/goal_manager)
 # Integration modules
 add_subdirectory(cpp/packages/integration/auto_fun)
 add_subdirectory(cpp/packages/integration/autonomous_starter)
+add_subdirectory(cpp/packages/integration/cognitive_curriculum)
 add_subdirectory(cpp/packages/integration/sweagent)
 add_subdirectory(cpp/packages/integration/mcp_gateway)
 add_subdirectory(cpp/packages/integration/cognitive_bridge)

--- a/cpp/packages/core/agentagenda/src/agentagenda.cpp
+++ b/cpp/packages/core/agentagenda/src/agentagenda.cpp
@@ -8,9 +8,12 @@
 #include <ctime>
 
 namespace elizaos {
-
 namespace {
-
+// Display-length limits used by planAgain() (backported from hurdcog fork).
+constexpr size_t MAX_COMPLETED_STEP_DISPLAY_LENGTH = 60;
+constexpr size_t MAX_REMAINING_STEP_DISPLAY_LENGTH = 55;
+constexpr size_t MAX_CONTEXT_STEP_LENGTH = 50;
+constexpr size_t MAX_REMAINING_STEPS_TO_SHOW = 3;
 std::string toLowerCopy(std::string value) {
     std::transform(value.begin(), value.end(), value.begin(),
         [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
@@ -110,9 +113,16 @@ AgendaTaskStatus AgentAgenda::stringToStatus(const std::string& status_str) {
 }
 
 std::string AgentAgenda::timestampToString(const std::chrono::system_clock::time_point& timepoint) {
-    auto time_t = std::chrono::system_clock::to_time_t(timepoint);
+    // Serialize with millisecond resolution. The previous implementation used
+    // to_time_t(), which floors to whole seconds; that made sub-second updates
+    // (e.g. planAgain() running a few ms after createTask) invisible after a
+    // persistence round-trip, breaking updated_at monotonicity. Storing the
+    // epoch in milliseconds preserves the ordering the autonomy loop relies on.
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  timepoint.time_since_epoch())
+                  .count();
     std::stringstream ss;
-    ss << time_t;
+    ss << ms;
     return ss.str();
 }
 
@@ -121,13 +131,14 @@ std::chrono::system_clock::time_point AgentAgenda::stringToTimestamp(const std::
         return std::chrono::system_clock::now();
     }
 
-    std::time_t parsed = 0;
+    long long parsed = 0;
     std::istringstream ss(timestamp_str);
     ss >> parsed;
     if (!ss || !ss.eof()) {
         return std::chrono::system_clock::now();
     }
-    return std::chrono::system_clock::from_time_t(parsed);
+    return std::chrono::system_clock::time_point(
+        std::chrono::milliseconds(parsed));
 }
 
 std::string AgentAgenda::serializeSteps(const std::vector<AgendaTaskStep>& steps) {
@@ -476,6 +487,100 @@ bool AgentAgenda::updatePlan(const std::string& task_id, const std::string& plan
     
     saveTaskToMemory(task);
     return true;
+}
+
+std::string AgentAgenda::planAgain(const std::string& task_id,
+                                    const std::string& context,
+                                    bool regenerate_steps) {
+    auto task = getTaskById(task_id);
+    if (task.id.empty()) {
+        return "";
+    }
+
+    // Analyze current task state
+    size_t completed_count = 0;
+    size_t total_steps = task.steps.size();
+    std::vector<std::string> completed_step_contents;
+    std::vector<std::string> remaining_step_contents;
+
+    for (const auto& step : task.steps) {
+        if (step.completed) {
+            completed_count++;
+            completed_step_contents.push_back(step.content);
+        } else {
+            remaining_step_contents.push_back(step.content);
+        }
+    }
+
+    // Build the new plan based on current progress
+    std::stringstream new_plan;
+    new_plan << "Re-planned for goal: " << task.goal << "\n\n";
+
+    if (total_steps > 0) {
+        new_plan << "Progress Summary:\n";
+        new_plan << "  - Completed: " << completed_count << "/" << total_steps << " steps\n";
+        if (!completed_step_contents.empty()) {
+            new_plan << "  - Already done:\n";
+            for (const auto& done : completed_step_contents) {
+                new_plan << "    * " << (done.size() > MAX_COMPLETED_STEP_DISPLAY_LENGTH ?
+                    done.substr(0, MAX_COMPLETED_STEP_DISPLAY_LENGTH - 3) + "..." : done) << "\n";
+            }
+        }
+        new_plan << "\n";
+    }
+
+    if (!context.empty()) {
+        new_plan << "Re-planning context: " << context << "\n\n";
+    }
+
+    new_plan << "Revised Strategy:\n";
+    if (remaining_step_contents.empty()) {
+        new_plan << "  1. Verify all completed work meets the original goal criteria\n";
+        new_plan << "  2. Document any lessons learned or improvements identified\n";
+        new_plan << "  3. Consider if additional scope or follow-up tasks are needed\n";
+        new_plan << "  4. Mark task as complete or extend with new steps\n";
+    } else {
+        new_plan << "  1. Review remaining work against original goal\n";
+        new_plan << "  2. Prioritize remaining steps based on current context\n";
+        new_plan << "  3. Execute highest-priority remaining actions:\n";
+        size_t step_num = 0;
+        for (const auto& remaining : remaining_step_contents) {
+            if (step_num >= MAX_REMAINING_STEPS_TO_SHOW) {
+                new_plan << "       (" << (remaining_step_contents.size() - MAX_REMAINING_STEPS_TO_SHOW) << " more steps...)\n";
+                break;
+            }
+            new_plan << "     - " << (remaining.size() > MAX_REMAINING_STEP_DISPLAY_LENGTH ?
+                remaining.substr(0, MAX_REMAINING_STEP_DISPLAY_LENGTH - 3) + "..." : remaining) << "\n";
+            step_num++;
+        }
+        new_plan << "  4. Validate results against the goal: " << task.goal << "\n";
+    }
+
+    std::string plan_result = new_plan.str();
+
+    task.plan = plan_result;
+    task.updated_at = std::chrono::system_clock::now();
+
+    if (regenerate_steps) {
+        std::vector<AgendaTaskStep> new_steps;
+        for (const auto& step : task.steps) {
+            if (step.completed) {
+                new_steps.push_back(step);
+            }
+        }
+        if (!context.empty()) {
+            new_steps.emplace_back("Address re-planning context: " +
+                (context.size() > MAX_CONTEXT_STEP_LENGTH ?
+                    context.substr(0, MAX_CONTEXT_STEP_LENGTH - 3) + "..." : context), false);
+        }
+        new_steps.emplace_back("Verify revised approach aligns with goal: " + task.goal, false);
+        new_steps.emplace_back("Execute revised plan actions", false);
+        new_steps.emplace_back("Validate final results and document completion", false);
+        task.steps = new_steps;
+    }
+
+    saveTaskToMemory(task);
+    return plan_result;
 }
 
 std::vector<AgendaTaskStep> AgentAgenda::createSteps(const std::string& goal, const std::string& plan) {

--- a/cpp/packages/integration/otaku/src/otaku.cpp
+++ b/cpp/packages/integration/otaku/src/otaku.cpp
@@ -1293,6 +1293,12 @@ LiquidityPosition OtakuAgent::addLiquidity(
     position.chainId = currentChain_;
     position.protocol = protocol;
 
+    // Track the opened position so it can be queried and removed later.
+    {
+        std::lock_guard<std::mutex> lock(liquidityMutex_);
+        liquidityPositions_.push_back(position);
+    }
+
     return position;
 }
 
@@ -1301,11 +1307,34 @@ bool OtakuAgent::removeLiquidity(const std::string& positionId, double percentag
     oss << "Removing " << percentage << "% liquidity from position " << positionId;
     elizaos::logInfo(oss.str(), "otaku");
 
+    // Clamp the requested percentage to a sane range.
+    if (percentage < 0.0) percentage = 0.0;
+    if (percentage > 100.0) percentage = 100.0;
+
+    std::lock_guard<std::mutex> lock(liquidityMutex_);
+    auto it = std::find_if(liquidityPositions_.begin(), liquidityPositions_.end(),
+                           [&positionId](const LiquidityPosition& p) {
+                               return p.positionId == positionId;
+                           });
+    if (it == liquidityPositions_.end()) {
+        return false;  // Unknown position id.
+    }
+
+    if (percentage >= 100.0) {
+        liquidityPositions_.erase(it);
+    } else {
+        const double remaining = 1.0 - (percentage / 100.0);
+        it->amount0 *= remaining;
+        it->amount1 *= remaining;
+        it->liquidityTokens *= remaining;
+        it->currentValue *= remaining;
+    }
     return true;
 }
 
 std::vector<LiquidityPosition> OtakuAgent::getLiquidityPositions() {
-    return {}; // Would return user's actual positions
+    std::lock_guard<std::mutex> lock(liquidityMutex_);
+    return liquidityPositions_;
 }
 
 double OtakuAgent::getPoolApr(const std::string& poolAddress, DexProtocol protocol) {

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -208,6 +208,10 @@ add_executable(otaku_test otaku_test.cpp)
 target_link_libraries(otaku_test elizaos-otaku gtest gtest_main Threads::Threads)
 add_test(NAME otaku_test COMMAND otaku_test)
 
+add_executable(otaku_liquidity_test otaku_liquidity_test.cpp)
+target_link_libraries(otaku_liquidity_test elizaos-otaku gtest gtest_main Threads::Threads)
+add_test(NAME otaku_liquidity_test COMMAND otaku_liquidity_test)
+
 add_executable(otc_agent_test otc_agent_test.cpp)
 target_link_libraries(otc_agent_test elizaos-otc_agent gtest gtest_main Threads::Threads)
 add_test(NAME otc_agent_test COMMAND otc_agent_test)

--- a/cpp/tests/agentagenda_test.cpp
+++ b/cpp/tests/agentagenda_test.cpp
@@ -1,5 +1,7 @@
 // agentagenda_test.cpp - E2E tests for elizaos::AgentAgenda.
 #include <gtest/gtest.h>
+#include <thread>
+#include <chrono>
 #include "elizaos/agentagenda.hpp"
 
 using namespace elizaos;
@@ -130,4 +132,66 @@ TEST_F(AgentAgendaTest, LastCreatedAndUpdated) {
     agenda.updatePlan(a.id, "newplan");
     auto last_updated = agenda.getLastUpdatedTask();
     EXPECT_EQ(last_updated.id, a.id);
+}
+
+
+// --- planAgain() adaptive re-planning (backported from hurdcog fork) ---
+
+TEST_F(AgentAgendaTest, PlanAgainBasic) {
+    auto t = agenda.createTask("complete the project");
+    auto new_plan = agenda.planAgain(t.id);
+    EXPECT_FALSE(new_plan.empty());
+    EXPECT_NE(new_plan.find("Re-planned"), std::string::npos);
+}
+
+TEST_F(AgentAgendaTest, PlanAgainWithContext) {
+    auto t = agenda.createTask("build feature");
+    auto new_plan = agenda.planAgain(t.id, "requirements changed");
+    EXPECT_NE(new_plan.find("Re-planning context"), std::string::npos);
+    EXPECT_NE(new_plan.find("requirements changed"), std::string::npos);
+}
+
+TEST_F(AgentAgendaTest, PlanAgainWithProgress) {
+    std::vector<AgendaTaskStep> steps{
+        AgendaTaskStep("step 1 done", true),
+        AgendaTaskStep("step 2 pending", false)
+    };
+    auto t = agenda.createTask("multi-step task", "original plan", steps);
+    auto new_plan = agenda.planAgain(t.id);
+    EXPECT_NE(new_plan.find("Progress Summary"), std::string::npos);
+    EXPECT_NE(new_plan.find("Completed:"), std::string::npos);
+}
+
+TEST_F(AgentAgendaTest, PlanAgainRegenerateSteps) {
+    std::vector<AgendaTaskStep> steps{
+        AgendaTaskStep("done step", true),
+        AgendaTaskStep("pending step", false)
+    };
+    auto t = agenda.createTask("task to replan", "original plan", steps);
+    auto new_plan = agenda.planAgain(t.id, "need new approach", true);
+    EXPECT_FALSE(new_plan.empty());
+
+    auto updated = agenda.getTaskById(t.id);
+    bool found_done = false;
+    for (const auto& s : updated.steps) {
+        if (s.content == "done step" && s.completed) found_done = true;
+    }
+    EXPECT_TRUE(found_done);
+}
+
+TEST_F(AgentAgendaTest, PlanAgainNonExistent) {
+    auto result = agenda.planAgain("non-existent-id");
+    EXPECT_TRUE(result.empty());
+}
+
+// Regression guard for the millisecond-resolution timestamp serialization:
+// a planAgain() a few ms after createTask must yield a strictly newer
+// updated_at after the persistence round-trip (previously floored to seconds).
+TEST_F(AgentAgendaTest, PlanAgainUpdatesTimestamp) {
+    auto t = agenda.createTask("timestamp monotonicity");
+    auto original_updated = agenda.getTaskById(t.id).updated_at;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    agenda.planAgain(t.id, "bump");
+    auto new_updated = agenda.getTaskById(t.id).updated_at;
+    EXPECT_GT(new_updated, original_updated);
 }

--- a/cpp/tests/otaku_liquidity_test.cpp
+++ b/cpp/tests/otaku_liquidity_test.cpp
@@ -1,0 +1,103 @@
+// otaku_liquidity_test.cpp
+//
+// End-to-end tests for the completed OtakuAgent liquidity-position lifecycle.
+// Previously getLiquidityPositions() returned a hard-coded empty vector and
+// removeLiquidity() was a no-op; these tests lock in the real behavior:
+// add -> track -> query, partial removal scaling, full removal, default-full
+// removal, unknown-position rejection, and over-percentage clamping.
+// (Behavior + tests backported from the hurdcog fork for cross-fork parity.)
+
+#include <gtest/gtest.h>
+
+#include "elizaos/otaku.hpp"
+
+#include <algorithm>
+#include <string>
+
+using namespace elizaos;
+
+namespace {
+
+OtakuAgent makeAgent() {
+    return OtakuAgent("otaku-liquidity-test");
+}
+
+TEST(OtakuLiquidity, AddLiquidityIsTrackedAndQueryable) {
+    OtakuAgent agent = makeAgent();
+    EXPECT_TRUE(agent.getLiquidityPositions().empty());
+
+    LiquidityPosition pos =
+        agent.addLiquidity("WETH", "USDC", 2.0, 4000.0, DexProtocol::UNISWAP_V3);
+
+    EXPECT_FALSE(pos.positionId.empty());
+    EXPECT_EQ(pos.token0, "WETH");
+    EXPECT_EQ(pos.token1, "USDC");
+
+    auto positions = agent.getLiquidityPositions();
+    ASSERT_EQ(positions.size(), 1u);
+    EXPECT_EQ(positions.front().positionId, pos.positionId);
+    EXPECT_DOUBLE_EQ(positions.front().amount0, 2.0);
+    EXPECT_DOUBLE_EQ(positions.front().amount1, 4000.0);
+}
+
+TEST(OtakuLiquidity, MultiplePositionsAreAllTracked) {
+    OtakuAgent agent = makeAgent();
+    agent.addLiquidity("WETH", "USDC", 1.0, 2000.0, DexProtocol::UNISWAP_V2);
+    agent.addLiquidity("WBTC", "USDC", 0.1, 6000.0, DexProtocol::SUSHISWAP);
+    agent.addLiquidity("DAI", "USDC", 500.0, 500.0, DexProtocol::CURVE);
+
+    EXPECT_EQ(agent.getLiquidityPositions().size(), 3u);
+}
+
+TEST(OtakuLiquidity, PartialRemovalScalesPositionDown) {
+    OtakuAgent agent = makeAgent();
+    LiquidityPosition pos =
+        agent.addLiquidity("WETH", "USDC", 4.0, 8000.0, DexProtocol::UNISWAP_V3);
+    const double originalLp = pos.liquidityTokens;
+
+    ASSERT_TRUE(agent.removeLiquidity(pos.positionId, 25.0));
+
+    auto positions = agent.getLiquidityPositions();
+    ASSERT_EQ(positions.size(), 1u);  // still present, just reduced
+    const auto& p = positions.front();
+    EXPECT_DOUBLE_EQ(p.amount0, 3.0);     // 4.0 * 0.75
+    EXPECT_DOUBLE_EQ(p.amount1, 6000.0);  // 8000 * 0.75
+    EXPECT_DOUBLE_EQ(p.liquidityTokens, originalLp * 0.75);
+}
+
+TEST(OtakuLiquidity, FullRemovalDeletesPosition) {
+    OtakuAgent agent = makeAgent();
+    LiquidityPosition pos =
+        agent.addLiquidity("WETH", "USDC", 1.0, 2000.0, DexProtocol::BALANCER);
+
+    ASSERT_TRUE(agent.removeLiquidity(pos.positionId, 100.0));
+    EXPECT_TRUE(agent.getLiquidityPositions().empty());
+}
+
+TEST(OtakuLiquidity, RemovalDefaultsToFull) {
+    OtakuAgent agent = makeAgent();
+    LiquidityPosition pos =
+        agent.addLiquidity("WETH", "USDC", 1.0, 2000.0, DexProtocol::UNISWAP_V3);
+
+    ASSERT_TRUE(agent.removeLiquidity(pos.positionId));  // default percentage = 100
+    EXPECT_TRUE(agent.getLiquidityPositions().empty());
+}
+
+TEST(OtakuLiquidity, RemovingUnknownPositionFails) {
+    OtakuAgent agent = makeAgent();
+    agent.addLiquidity("WETH", "USDC", 1.0, 2000.0, DexProtocol::UNISWAP_V3);
+
+    EXPECT_FALSE(agent.removeLiquidity("does-not-exist", 50.0));
+    EXPECT_EQ(agent.getLiquidityPositions().size(), 1u);  // unchanged
+}
+
+TEST(OtakuLiquidity, OverPercentageIsClampedToFullRemoval) {
+    OtakuAgent agent = makeAgent();
+    LiquidityPosition pos =
+        agent.addLiquidity("WETH", "USDC", 1.0, 2000.0, DexProtocol::UNISWAP_V3);
+
+    ASSERT_TRUE(agent.removeLiquidity(pos.positionId, 250.0));  // clamped to 100
+    EXPECT_TRUE(agent.getLiquidityPositions().empty());
+}
+
+}  // namespace

--- a/include/elizaos/agentagenda.hpp
+++ b/include/elizaos/agentagenda.hpp
@@ -157,7 +157,23 @@ public:
      * @return True if plan was updated, false otherwise
      */
     bool updatePlan(const std::string& task_id, const std::string& plan);
-    
+
+    /**
+     * @brief Re-plan an existing task based on current progress
+     *
+     * Analyzes the current state of a task (completed steps, remaining steps,
+     * and the original goal) and generates a new plan that accounts for what
+     * has already been done. Backported from hurdcog fork for cross-fork parity.
+     *
+     * @param task_id The ID of the task to re-plan
+     * @param context Optional additional context for re-planning
+     * @param regenerate_steps If true, also regenerates the steps based on the new plan
+     * @return The new plan string, or empty string if task not found
+     */
+    std::string planAgain(const std::string& task_id,
+                          const std::string& context = "",
+                          bool regenerate_steps = false);
+
     /**
      * @brief Create steps for a goal and plan
      * @param goal The goal

--- a/include/elizaos/otaku.hpp
+++ b/include/elizaos/otaku.hpp
@@ -544,6 +544,11 @@ private:
     // Callbacks
     std::function<void(const std::string&)> statusCallback_;
 
+    // Open liquidity positions opened via addLiquidity(), keyed by positionId.
+    // Backported from hurdcog fork to complete the liquidity-position lifecycle.
+    std::vector<LiquidityPosition> liquidityPositions_;
+    mutable std::mutex liquidityMutex_;
+
     // Thread safety
     mutable std::mutex agentMutex_;
 


### PR DESCRIPTION
Registers cognitive_curriculum in the ROOT CMakeLists (fixes link cascade that reported ~67 failures), completes the stubbed otaku liquidity lifecycle (+7 tests), and backports planAgain() adaptive re-planning and millisecond-resolution timestamps from hurdcog (+ agenda tests). Full ctest: 83/83.