### PR TITLE
feat(autonomy,attention): uplift to closed-loop autonomy parity with hurdcog

### DIFF
--- a/cpp/packages/core/agentagenda/src/agentagenda.cpp
+++ b/cpp/packages/core/agentagenda/src/agentagenda.cpp
@@ -110,9 +110,17 @@ AgendaTaskStatus AgentAgenda::stringToStatus(const std::string& status_str) {
 }
 
 std::string AgentAgenda::timestampToString(const std::chrono::system_clock::time_point& timepoint) {
-    auto time_t = std::chrono::system_clock::to_time_t(timepoint);
+    // Persist the FULL clock resolution (nanoseconds since epoch), not whole
+    // seconds. Serializing via to_time_t() truncated every timestamp down to the
+    // second, so a save/load round-trip could return a value strictly less than
+    // the original in-memory timestamp -- breaking monotonic "updated_at moved
+    // forward" invariants for sub-second updates. Storing the raw tick count is
+    // lossless and round-trips exactly.
+    const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        timepoint.time_since_epoch())
+                        .count();
     std::stringstream ss;
-    ss << time_t;
+    ss << ns;
     return ss.str();
 }
 
@@ -121,13 +129,13 @@ std::chrono::system_clock::time_point AgentAgenda::stringToTimestamp(const std::
         return std::chrono::system_clock::now();
     }
 
-    std::time_t parsed = 0;
+    long long parsed = 0;
     std::istringstream ss(timestamp_str);
     ss >> parsed;
     if (!ss || !ss.eof()) {
         return std::chrono::system_clock::now();
     }
-    return std::chrono::system_clock::from_time_t(parsed);
+    return std::chrono::system_clock::time_point(std::chrono::nanoseconds(parsed));
 }
 
 std::string AgentAgenda::serializeSteps(const std::vector<AgendaTaskStep>& steps) {

--- a/cpp/packages/core/agentmemory/src/attention.cpp
+++ b/cpp/packages/core/agentmemory/src/attention.cpp
@@ -7,6 +7,8 @@
 #include <random>
 #include <sstream>
 #include <cctype>
+#include <unordered_set>
+#include <map>
 namespace elizaos {
 
 // AttentionBudget Implementation
@@ -1020,5 +1022,1132 @@ namespace attention {
         getGlobalAttentionAwareMemoryManager().getAttentionAllocator()->decayAttentionValues(decayRate);
     }
 }
+
+// ============================================================================
+// Phase 1.3: SaliencyDetector Implementation
+// ============================================================================
+
+void SaliencyDetector::initializeEmotionalKeywords() {
+    // Positive emotions
+    emotionalKeywords_["happy"] = 0.8;
+    emotionalKeywords_["joy"] = 0.85;
+    emotionalKeywords_["excited"] = 0.9;
+    emotionalKeywords_["love"] = 0.95;
+    emotionalKeywords_["amazing"] = 0.8;
+    emotionalKeywords_["wonderful"] = 0.75;
+    
+    // Negative emotions
+    emotionalKeywords_["sad"] = 0.7;
+    emotionalKeywords_["angry"] = 0.85;
+    emotionalKeywords_["fear"] = 0.9;
+    emotionalKeywords_["danger"] = 0.95;
+    emotionalKeywords_["urgent"] = 0.9;
+    emotionalKeywords_["critical"] = 0.95;
+    emotionalKeywords_["error"] = 0.8;
+    emotionalKeywords_["warning"] = 0.75;
+    
+    // Cognitive importance
+    emotionalKeywords_["important"] = 0.85;
+    emotionalKeywords_["remember"] = 0.7;
+    emotionalKeywords_["priority"] = 0.8;
+    emotionalKeywords_["deadline"] = 0.9;
+}
+
+SaliencyDetector::SaliencyFeatures SaliencyDetector::calculateSaliency(
+    const std::string& content,
+    const std::vector<std::string>& context,
+    const std::vector<std::string>& currentGoals) {
+    
+    SaliencyFeatures features;
+    
+    // Initialize emotional keywords if not done
+    if (emotionalKeywords_.empty()) {
+        initializeEmotionalKeywords();
+    }
+    
+    // Calculate semantic saliency based on content length and complexity
+    double wordCount = 0;
+    double uniqueChars = 0;
+    std::unordered_set<char> charSet;
+    for (char c : content) {
+        charSet.insert(c);
+        if (c == ' ') wordCount++;
+    }
+    wordCount = std::max(1.0, wordCount);
+    uniqueChars = static_cast<double>(charSet.size());
+    features.semanticSaliency = std::min(1.0, (uniqueChars / 52.0) * 0.5 + 
+                                              (std::min(wordCount, 100.0) / 100.0) * 0.5);
+    
+    // Calculate emotional saliency
+    std::string lowerContent = content;
+    std::transform(lowerContent.begin(), lowerContent.end(), 
+                   lowerContent.begin(), ::tolower);
+    
+    double maxEmotional = 0.0;
+    int emotionalMatches = 0;
+    for (const auto& [keyword, score] : emotionalKeywords_) {
+        if (lowerContent.find(keyword) != std::string::npos) {
+            maxEmotional = std::max(maxEmotional, score);
+            emotionalMatches++;
+        }
+    }
+    features.emotionalSaliency = maxEmotional * (1.0 + std::min(emotionalMatches, 5) * 0.1);
+    features.emotionalSaliency = std::min(1.0, features.emotionalSaliency);
+    
+    // Calculate goal relevance
+    double goalRelevance = 0.0;
+    for (const auto& goal : currentGoals) {
+        std::string lowerGoal = goal;
+        std::transform(lowerGoal.begin(), lowerGoal.end(), lowerGoal.begin(), ::tolower);
+        
+        // Check for keyword overlap
+        std::istringstream goalStream(lowerGoal);
+        std::string goalWord;
+        while (goalStream >> goalWord) {
+            if (goalWord.length() > 3 && lowerContent.find(goalWord) != std::string::npos) {
+                goalRelevance += 0.2;
+            }
+        }
+    }
+    features.goalRelevance = std::min(1.0, goalRelevance);
+    
+    // Calculate temporal saliency (based on recency in context)
+    if (!context.empty()) {
+        // Check if content appears in recent context
+        for (size_t i = 0; i < std::min(context.size(), size_t(5)); i++) {
+            if (context[i].find(content.substr(0, std::min(size_t(20), content.size()))) 
+                != std::string::npos) {
+                features.temporalSaliency = 1.0 - (i * 0.15);
+                break;
+            }
+        }
+    }
+    
+    // Visual saliency - detect special formatting or structure
+    int specialChars = 0;
+    for (char c : content) {
+        if (c == '!' || c == '?' || c == '*' || c == '#' || c == '@') {
+            specialChars++;
+        }
+    }
+    features.visualSaliency = std::min(1.0, specialChars * 0.1);
+    
+    return features;
+}
+
+std::vector<UUID> SaliencyDetector::identifyAttentionShiftTargets(
+    const std::unordered_map<UUID, AttentionValue>& currentAttention,
+    const std::vector<std::pair<UUID, SaliencyFeatures>>& candidates,
+    size_t maxShifts) {
+    
+    std::vector<std::pair<UUID, double>> scoredCandidates;
+    
+    for (const auto& [id, features] : candidates) {
+        double saliencyScore = features.getOverallSaliency();
+        
+        // Check current attention - prefer items not already attended
+        double currentAttentionPenalty = 0.0;
+        auto it = currentAttention.find(id);
+        if (it != currentAttention.end()) {
+            currentAttentionPenalty = it->second.sti() * 0.3;
+        }
+        
+        double finalScore = saliencyScore - currentAttentionPenalty;
+        scoredCandidates.emplace_back(id, finalScore);
+    }
+    
+    // Sort by score descending
+    std::sort(scoredCandidates.begin(), scoredCandidates.end(),
+              [](const auto& a, const auto& b) { return a.second > b.second; });
+    
+    // Extract top targets
+    std::vector<UUID> targets;
+    for (size_t i = 0; i < std::min(maxShifts, scoredCandidates.size()); i++) {
+        if (scoredCandidates[i].second > 0.1) {  // Minimum threshold
+            targets.push_back(scoredCandidates[i].first);
+        }
+    }
+    
+    return targets;
+}
+
+void SaliencyDetector::setWeights(double visual, double semantic, double temporal,
+                                  double emotional, double goal) {
+    visualWeight_ = visual;
+    semanticWeight_ = semantic;
+    temporalWeight_ = temporal;
+    emotionalWeight_ = emotional;
+    goalWeight_ = goal;
+}
+
+// ============================================================================
+// Phase 1.3: AttentionCostBudget Implementation
+// ============================================================================
+
+AttentionCostBudget::AttentionCostBudget(double totalBudget, double regenerationRate)
+    : totalBudget_(totalBudget)
+    , availableBudget_(totalBudget)
+    , regenerationRate_(regenerationRate) {}
+
+AttentionCostBudget::AllocationResult AttentionCostBudget::requestAllocation(
+    const AllocationRequest& request) {
+    
+    std::lock_guard<std::mutex> lock(budgetMutex_);
+    
+    AllocationResult result;
+    double available = availableBudget_.load();
+    
+    if (available < 0.01) {
+        result.success = false;
+        result.allocatedAmount = 0.0;
+        result.remainingBudget = available;
+        result.reason = "Budget exhausted";
+        return result;
+    }
+    
+    double toAllocate = request.requestedAmount;
+    
+    if (toAllocate > available) {
+        if (request.canPartialAllocate) {
+            toAllocate = available;
+        } else {
+            result.success = false;
+            result.allocatedAmount = 0.0;
+            result.remainingBudget = available;
+            result.reason = "Insufficient budget for full allocation";
+            return result;
+        }
+    }
+    
+    // Perform allocation
+    availableBudget_.store(availableBudget_.load() - toAllocate);
+    activeAllocations_[request.targetId] += toAllocate;
+    
+    // Record history
+    AllocationHistory hist;
+    hist.targetId = request.targetId;
+    hist.amount = toAllocate;
+    hist.allocatedAt = std::chrono::system_clock::now();
+    hist.isActive = true;
+    history_.push_back(hist);
+    
+    result.success = true;
+    result.allocatedAmount = toAllocate;
+    result.remainingBudget = availableBudget_.load();
+    result.reason = "Allocated successfully";
+    
+    return result;
+}
+
+void AttentionCostBudget::releaseAttention(const UUID& targetId, double amount) {
+    std::lock_guard<std::mutex> lock(budgetMutex_);
+    
+    auto it = activeAllocations_.find(targetId);
+    if (it != activeAllocations_.end()) {
+        double toRelease = std::min(amount, it->second);
+        it->second -= toRelease;
+        
+        if (it->second <= 0.01) {
+            activeAllocations_.erase(it);
+        }
+        
+        double newBudget = availableBudget_.load() + toRelease;
+        availableBudget_.store(std::min(newBudget, totalBudget_));
+        
+        // Update history
+        for (auto& hist : history_) {
+            if (hist.targetId == targetId && hist.isActive) {
+                hist.isActive = false;
+                break;
+            }
+        }
+    }
+}
+
+double AttentionCostBudget::getAvailableBudget() const {
+    return availableBudget_.load();
+}
+
+void AttentionCostBudget::setTotalBudget(double budget) {
+    std::lock_guard<std::mutex> lock(budgetMutex_);
+    double diff = budget - totalBudget_;
+    totalBudget_ = budget;
+    if (diff > 0) {
+        availableBudget_.store(availableBudget_.load() + diff);
+    }
+}
+
+void AttentionCostBudget::setRegenerationRate(double rate) {
+    regenerationRate_ = rate;
+}
+
+void AttentionCostBudget::tick(double deltaSeconds) {
+    double regeneration = regenerationRate_ * deltaSeconds;
+    double newBudget = availableBudget_.load() + regeneration;
+    availableBudget_.store(std::min(newBudget, totalBudget_));
+}
+
+std::vector<AttentionCostBudget::AllocationHistory> 
+AttentionCostBudget::getAllocationHistory() const {
+    std::lock_guard<std::mutex> lock(budgetMutex_);
+    return history_;
+}
+
+void AttentionCostBudget::emergencyRelease(double threshold) {
+    std::lock_guard<std::mutex> lock(budgetMutex_);
+    
+    if (availableBudget_.load() < totalBudget_ * threshold) {
+        // Release all non-critical allocations
+        double released = 0.0;
+        for (auto it = activeAllocations_.begin(); it != activeAllocations_.end();) {
+            released += it->second;
+            it = activeAllocations_.erase(it);
+        }
+        
+        double newBudget = availableBudget_.load() + released;
+        availableBudget_.store(std::min(newBudget, totalBudget_));
+        
+        // Mark all history as inactive
+        for (auto& hist : history_) {
+            hist.isActive = false;
+        }
+    }
+}
+
+// ============================================================================
+// Phase 1.3: AttentionPatternLearner Implementation
+// ============================================================================
+
+AttentionPatternLearner::AttentionPatternLearner() {
+    eventHistory_.reserve(1000);
+}
+
+void AttentionPatternLearner::recordEvent(const AttentionEvent& event) {
+    std::lock_guard<std::mutex> lock(learnerMutex_);
+    
+    eventHistory_.push_back(event);
+    
+    // Trim history if too large
+    if (eventHistory_.size() > maxHistorySize_) {
+        eventHistory_.erase(eventHistory_.begin(), 
+                           eventHistory_.begin() + (eventHistory_.size() - maxHistorySize_));
+    }
+}
+
+void AttentionPatternLearner::detectTemporalPatterns() {
+    // Detect daily/hourly patterns
+    std::unordered_map<int, std::vector<UUID>> hourlyTargets;
+    
+    for (const auto& event : eventHistory_) {
+        auto time = std::chrono::system_clock::to_time_t(event.timestamp);
+        std::tm* tm = std::localtime(&time);
+        int hour = tm->tm_hour;
+        hourlyTargets[hour].push_back(event.targetId);
+    }
+    
+    // Find consistent hourly patterns
+    for (const auto& [hour, targets] : hourlyTargets) {
+        if (targets.size() >= 3) {  // At least 3 occurrences
+            // Count target frequencies
+            std::unordered_map<UUID, int> targetCounts;
+            for (const auto& t : targets) {
+                targetCounts[t]++;
+            }
+            
+            // Find frequent targets
+            std::vector<UUID> frequentTargets;
+            for (const auto& [target, count] : targetCounts) {
+                if (count >= 2) {
+                    frequentTargets.push_back(target);
+                }
+            }
+            
+            if (!frequentTargets.empty()) {
+                LearnedPattern pattern;
+                pattern.patternType = "temporal";
+                pattern.triggers.push_back("hour:" + std::to_string(hour));
+                pattern.predictedTargets = frequentTargets;
+                pattern.confidence = static_cast<double>(frequentTargets.size()) / targets.size();
+                pattern.occurrenceCount = static_cast<int>(targets.size());
+                learnedPatterns_.push_back(pattern);
+            }
+        }
+    }
+}
+
+void AttentionPatternLearner::detectContextualPatterns() {
+    // Group events by context
+    std::unordered_map<std::string, std::vector<UUID>> contextTargets;
+    
+    for (const auto& event : eventHistory_) {
+        for (const auto& [key, value] : event.context) {
+            std::string contextKey = key + ":" + value;
+            contextTargets[contextKey].push_back(event.targetId);
+        }
+    }
+    
+    // Find patterns
+    for (const auto& [context, targets] : contextTargets) {
+        if (targets.size() >= 3) {
+            std::unordered_map<UUID, int> targetCounts;
+            for (const auto& t : targets) {
+                targetCounts[t]++;
+            }
+            
+            std::vector<UUID> frequentTargets;
+            for (const auto& [target, count] : targetCounts) {
+                if (count >= 2) {
+                    frequentTargets.push_back(target);
+                }
+            }
+            
+            if (!frequentTargets.empty()) {
+                LearnedPattern pattern;
+                pattern.patternType = "contextual";
+                pattern.triggers.push_back(context);
+                pattern.predictedTargets = frequentTargets;
+                pattern.confidence = static_cast<double>(frequentTargets.size()) / targets.size();
+                pattern.occurrenceCount = static_cast<int>(targets.size());
+                learnedPatterns_.push_back(pattern);
+            }
+        }
+    }
+}
+
+void AttentionPatternLearner::detectSequentialPatterns() {
+    // Detect A -> B sequential patterns
+    if (eventHistory_.size() < 2) return;
+    
+    std::map<std::pair<UUID, UUID>, int> sequenceCounts;
+    
+    for (size_t i = 1; i < eventHistory_.size(); i++) {
+        // Check if events are close in time (within 5 minutes)
+        auto timeDiff = eventHistory_[i].timestamp - eventHistory_[i-1].timestamp;
+        if (timeDiff < std::chrono::minutes(5)) {
+            auto key = std::make_pair(eventHistory_[i-1].targetId, eventHistory_[i].targetId);
+            sequenceCounts[key]++;
+        }
+    }
+    
+    // Create patterns for frequent sequences
+    for (const auto& [sequence, count] : sequenceCounts) {
+        if (count >= 3) {
+            LearnedPattern pattern;
+            pattern.patternType = "sequential";
+            pattern.triggers.push_back("after:" + sequence.first);
+            pattern.predictedTargets.push_back(sequence.second);
+            pattern.confidence = std::min(1.0, count / 10.0);
+            pattern.occurrenceCount = count;
+            learnedPatterns_.push_back(pattern);
+        }
+    }
+}
+
+void AttentionPatternLearner::learnPatterns() {
+    std::lock_guard<std::mutex> lock(learnerMutex_);
+    
+    // Clear old patterns
+    learnedPatterns_.clear();
+    
+    // Detect different types of patterns
+    detectTemporalPatterns();
+    detectContextualPatterns();
+    detectSequentialPatterns();
+    
+    // Prune low-confidence patterns
+    learnedPatterns_.erase(
+        std::remove_if(learnedPatterns_.begin(), learnedPatterns_.end(),
+            [this](const LearnedPattern& p) { 
+                return p.confidence < minPatternConfidence_; 
+            }),
+        learnedPatterns_.end());
+}
+
+std::vector<std::pair<UUID, double>> AttentionPatternLearner::predictAttentionNeeds(
+    const std::unordered_map<std::string, std::string>& currentContext,
+    size_t maxPredictions) {
+    
+    std::lock_guard<std::mutex> lock(learnerMutex_);
+    
+    std::unordered_map<UUID, double> predictions;
+    
+    // Get current hour
+    auto now = std::chrono::system_clock::now();
+    auto time = std::chrono::system_clock::to_time_t(now);
+    std::tm* tm = std::localtime(&time);
+    int currentHour = tm->tm_hour;
+    
+    for (const auto& pattern : learnedPatterns_) {
+        bool triggered = false;
+        
+        // Check temporal triggers
+        for (const auto& trigger : pattern.triggers) {
+            if (trigger.find("hour:") == 0) {
+                int hour = std::stoi(trigger.substr(5));
+                if (hour == currentHour) {
+                    triggered = true;
+                    break;
+                }
+            }
+            
+            // Check contextual triggers
+            for (const auto& [key, value] : currentContext) {
+                if (trigger == key + ":" + value) {
+                    triggered = true;
+                    break;
+                }
+            }
+            
+            if (triggered) break;
+        }
+        
+        if (triggered) {
+            for (const auto& target : pattern.predictedTargets) {
+                predictions[target] += pattern.confidence;
+            }
+        }
+    }
+    
+    // Sort by prediction confidence
+    std::vector<std::pair<UUID, double>> result(predictions.begin(), predictions.end());
+    std::sort(result.begin(), result.end(),
+              [](const auto& a, const auto& b) { return a.second > b.second; });
+    
+    if (result.size() > maxPredictions) {
+        result.resize(maxPredictions);
+    }
+    
+    return result;
+}
+
+std::vector<AttentionPatternLearner::LearnedPattern> 
+AttentionPatternLearner::getPatterns() const {
+    std::lock_guard<std::mutex> lock(learnerMutex_);
+    return learnedPatterns_;
+}
+
+void AttentionPatternLearner::prunePatterns(double minConfidence) {
+    std::lock_guard<std::mutex> lock(learnerMutex_);
+    
+    learnedPatterns_.erase(
+        std::remove_if(learnedPatterns_.begin(), learnedPatterns_.end(),
+            [minConfidence](const LearnedPattern& p) { 
+                return p.confidence < minConfidence; 
+            }),
+        learnedPatterns_.end());
+}
+
+// ============================================================================
+// Phase 1.3: AttentionTransferProtocol Implementation
+// ============================================================================
+
+AttentionTransferProtocol::AttentionTransferProtocol(const std::string& agentId)
+    : agentId_(agentId) {}
+
+AttentionTransferProtocol::~AttentionTransferProtocol() {
+    // Ensure we are not left dangling inside a bus registry.
+    disconnectFromBus();
+}
+
+void AttentionTransferProtocol::trackTransferLocked(const AttentionTransferRequest& request) {
+    ActiveTransfer transfer;
+    transfer.request = request;
+    transfer.startTime = std::chrono::system_clock::now();
+    transfer.expiresAt = transfer.startTime + request.duration;
+    transfer.isIncoming = (request.targetAgentId == agentId_);
+    activeTransfers_.push_back(transfer);
+}
+
+void AttentionTransferProtocol::cleanupExpiredTransfers() {
+    auto now = std::chrono::system_clock::now();
+    
+    activeTransfers_.erase(
+        std::remove_if(activeTransfers_.begin(), activeTransfers_.end(),
+            [&now](const ActiveTransfer& t) { return now > t.expiresAt; }),
+        activeTransfers_.end());
+}
+
+AttentionTransferProtocol::AttentionTransferResponse 
+AttentionTransferProtocol::requestTransfer(const AttentionTransferRequest& request) {
+    // If connected to a bus and the request targets a different, registered
+    // agent, route it across the boundary so the *target* decides.
+    AttentionMessageBus* bus = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(transferMutex_);
+        bus = bus_;
+    }
+    if (bus && !request.targetAgentId.empty() && request.targetAgentId != agentId_) {
+        if (!bus->isRegistered(request.targetAgentId)) {
+            // Explicit cross-agent request to a target that is not on the bus:
+            // reject as undeliverable rather than silently self-accepting.
+            AttentionTransferResponse response;
+            response.accepted = false;
+            response.actualAmount = 0.0;
+            response.message = "Target agent '" + request.targetAgentId +
+                               "' not registered on bus";
+            return response;
+        }
+        AttentionTransferRequestEnvelope envelope;
+        envelope.sourceAgentId = request.sourceAgentId.empty() ? agentId_ : request.sourceAgentId;
+        envelope.targetAgentId = request.targetAgentId;
+        envelope.memoryOrTaskId = request.memoryOrTaskId;
+        envelope.attentionAmount = request.attentionAmount;
+        envelope.reason = request.reason;
+        envelope.duration = request.duration;
+        auto routed = bus->routeTransfer(envelope);
+
+        AttentionTransferResponse response;
+        response.accepted = routed.accepted;
+        response.actualAmount = routed.actualAmount;
+        response.message = routed.message;
+
+        // Record the outgoing transfer locally when the remote accepted.
+        if (response.accepted) {
+            std::lock_guard<std::mutex> lock(transferMutex_);
+            trackTransferLocked(request);
+            cleanupExpiredTransfers();
+        }
+        return response;
+    }
+
+    std::lock_guard<std::mutex> lock(transferMutex_);
+    AttentionTransferResponse response = evaluateTransferLocked(request);
+    if (response.accepted) {
+        trackTransferLocked(request);
+    }
+    cleanupExpiredTransfers();
+    return response;
+}
+
+AttentionTransferProtocol::AttentionTransferResponse
+AttentionTransferProtocol::handleRoutedTransfer(const AttentionTransferRequest& request) {
+    std::lock_guard<std::mutex> lock(transferMutex_);
+    AttentionTransferResponse response = evaluateTransferLocked(request);
+    if (response.accepted) {
+        // The receiving agent records this as an incoming transfer.
+        AttentionTransferRequest incoming = request;
+        incoming.targetAgentId = agentId_;
+        trackTransferLocked(incoming);
+    }
+    cleanupExpiredTransfers();
+    return response;
+}
+
+void AttentionTransferProtocol::setTransferHandler(TransferHandler handler) {
+    std::lock_guard<std::mutex> lock(transferMutex_);
+    transferHandler_ = handler;
+}
+
+size_t AttentionTransferProtocol::broadcastFocus(const std::vector<UUID>& focusedItems) {
+    // Always trigger the locally-installed handler (back-compatible behavior).
+    FocusBroadcastHandler localHandler;
+    AttentionMessageBus* bus = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(transferMutex_);
+        localHandler = focusBroadcastHandler_;
+        bus = bus_;
+    }
+    if (localHandler) {
+        localHandler(agentId_, focusedItems);
+    }
+    // When connected to a bus, publish across the agent boundary to every
+    // other registered endpoint and any out-of-band listeners.
+    if (bus) {
+        return bus->publishFocus(agentId_, focusedItems);
+    }
+    return 0;
+}
+
+void AttentionTransferProtocol::deliverFocusBroadcast(const std::string& sourceAgentId,
+                                                      const std::vector<UUID>& focusedItems) {
+    FocusBroadcastHandler localHandler;
+    {
+        std::lock_guard<std::mutex> lock(transferMutex_);
+        localHandler = focusBroadcastHandler_;
+    }
+    if (localHandler) {
+        localHandler(sourceAgentId, focusedItems);
+    }
+}
+
+void AttentionTransferProtocol::setFocusBroadcastHandler(FocusBroadcastHandler handler) {
+    std::lock_guard<std::mutex> lock(transferMutex_);
+    focusBroadcastHandler_ = handler;
+}
+
+void AttentionTransferProtocol::connectToBus(AttentionMessageBus* bus) {
+    AttentionMessageBus* previous = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(transferMutex_);
+        previous = bus_;
+        bus_ = bus;
+    }
+    if (previous && previous != bus) {
+        previous->unregisterAgent(agentId_);
+    }
+    if (bus) {
+        bus->registerAgent(agentId_, this);
+    }
+}
+
+void AttentionTransferProtocol::disconnectFromBus() {
+    AttentionMessageBus* previous = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(transferMutex_);
+        previous = bus_;
+        bus_ = nullptr;
+    }
+    if (previous) {
+        previous->unregisterAgent(agentId_);
+    }
+}
+
+bool AttentionTransferProtocol::isConnectedToBus() const {
+    std::lock_guard<std::mutex> lock(transferMutex_);
+    return bus_ != nullptr;
+}
+
+void AttentionTransferProtocol::contributeToPool(const std::string& poolId, double amount) {
+    std::lock_guard<std::mutex> lock(transferMutex_);
+    attentionPools_[poolId] += amount;
+}
+
+double AttentionTransferProtocol::withdrawFromPool(const std::string& poolId, 
+                                                   double requestedAmount) {
+    std::lock_guard<std::mutex> lock(transferMutex_);
+    
+    auto it = attentionPools_.find(poolId);
+    if (it == attentionPools_.end()) {
+        return 0.0;
+    }
+    
+    double withdrawn = std::min(requestedAmount, it->second);
+    it->second -= withdrawn;
+    
+    if (it->second <= 0.01) {
+        attentionPools_.erase(it);
+    }
+    
+    return withdrawn;
+}
+
+double AttentionTransferProtocol::getPoolBalance(const std::string& poolId) const {
+    std::lock_guard<std::mutex> lock(transferMutex_);
+    
+    auto it = attentionPools_.find(poolId);
+    return (it != attentionPools_.end()) ? it->second : 0.0;
+}
+
+std::vector<AttentionTransferProtocol::ActiveTransfer> 
+AttentionTransferProtocol::getActiveTransfers() const {
+    std::lock_guard<std::mutex> lock(transferMutex_);
+    return activeTransfers_;
+}
+
+AttentionTransferProtocol::AttentionTransferResponse
+AttentionTransferProtocol::evaluateTransferLocked(const AttentionTransferRequest& request) {
+    AttentionTransferResponse response;
+    if (transferHandler_) {
+        response = transferHandler_(request);
+    } else {
+        // Default policy: accept transfers at or below the threshold.
+        if (request.attentionAmount <= 10.0) {
+            response.accepted = true;
+            response.actualAmount = request.attentionAmount;
+            response.message = "Transfer accepted";
+        } else {
+            response.accepted = false;
+            response.actualAmount = 0.0;
+            response.message = "Transfer amount too high";
+        }
+    }
+    return response;
+}
+
+// ============================================================================
+// Phase 1.3: AttentionMessageBus Implementation
+// ============================================================================
+
+AttentionMessageBus& AttentionMessageBus::instance() {
+    static AttentionMessageBus bus;
+    return bus;
+}
+
+void AttentionMessageBus::registerAgent(const std::string& agentId,
+                                        AttentionTransferProtocol* protocol) {
+    if (agentId.empty() || protocol == nullptr) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(busMutex_);
+    endpoints_[agentId] = protocol;
+}
+
+void AttentionMessageBus::unregisterAgent(const std::string& agentId) {
+    std::lock_guard<std::mutex> lock(busMutex_);
+    endpoints_.erase(agentId);
+}
+
+bool AttentionMessageBus::isRegistered(const std::string& agentId) const {
+    std::lock_guard<std::mutex> lock(busMutex_);
+    return endpoints_.find(agentId) != endpoints_.end();
+}
+
+size_t AttentionMessageBus::agentCount() const {
+    std::lock_guard<std::mutex> lock(busMutex_);
+    return endpoints_.size();
+}
+
+size_t AttentionMessageBus::publishFocus(const std::string& sourceAgentId,
+                                         const std::vector<UUID>& focusedItems) {
+    // Snapshot endpoints and listeners under lock, then dispatch without the
+    // lock held to avoid re-entrant deadlocks if a listener calls back in.
+    std::vector<AttentionTransferProtocol*> targets;
+    std::vector<FocusListener> listenerSnapshot;
+    {
+        std::lock_guard<std::mutex> lock(busMutex_);
+        targets.reserve(endpoints_.size());
+        for (const auto& kv : endpoints_) {
+            if (kv.first != sourceAgentId && kv.second != nullptr) {
+                targets.push_back(kv.second);
+            }
+        }
+        listenerSnapshot.reserve(listeners_.size());
+        for (const auto& kv : listeners_) {
+            listenerSnapshot.push_back(kv.second);
+        }
+    }
+    for (auto* target : targets) {
+        target->deliverFocusBroadcast(sourceAgentId, focusedItems);
+    }
+    for (auto& listener : listenerSnapshot) {
+        if (listener) {
+            listener(sourceAgentId, focusedItems);
+        }
+    }
+    return targets.size();
+}
+
+size_t AttentionMessageBus::subscribe(FocusListener listener) {
+    std::lock_guard<std::mutex> lock(busMutex_);
+    size_t id = nextSubscriptionId_++;
+    listeners_[id] = std::move(listener);
+    return id;
+}
+
+void AttentionMessageBus::unsubscribe(size_t subscriptionId) {
+    std::lock_guard<std::mutex> lock(busMutex_);
+    listeners_.erase(subscriptionId);
+}
+
+AttentionMessageBus::RoutedTransferResult
+AttentionMessageBus::routeTransfer(const AttentionTransferRequestEnvelope& envelope) {
+    AttentionTransferProtocol* target = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(busMutex_);
+        auto it = endpoints_.find(envelope.targetAgentId);
+        if (it != endpoints_.end()) {
+            target = it->second;
+        }
+    }
+
+    RoutedTransferResult result;
+    if (target == nullptr) {
+        result.delivered = false;
+        result.accepted = false;
+        result.actualAmount = 0.0;
+        result.message = "Target agent '" + envelope.targetAgentId + "' not registered on bus";
+        return result;
+    }
+
+    AttentionTransferProtocol::AttentionTransferRequest request;
+    request.sourceAgentId = envelope.sourceAgentId;
+    request.targetAgentId = envelope.targetAgentId;
+    request.memoryOrTaskId = envelope.memoryOrTaskId;
+    request.attentionAmount = envelope.attentionAmount;
+    request.reason = envelope.reason;
+    request.duration = envelope.duration;
+
+    auto response = target->handleRoutedTransfer(request);
+    result.delivered = true;
+    result.accepted = response.accepted;
+    result.actualAmount = response.actualAmount;
+    result.message = response.message;
+    return result;
+}
+
+void AttentionMessageBus::contributeToSharedPool(const std::string& poolId, double amount) {
+    std::lock_guard<std::mutex> lock(busMutex_);
+    sharedPools_[poolId] += amount;
+}
+
+double AttentionMessageBus::withdrawFromSharedPool(const std::string& poolId,
+                                                   double requestedAmount) {
+    std::lock_guard<std::mutex> lock(busMutex_);
+    auto it = sharedPools_.find(poolId);
+    if (it == sharedPools_.end()) {
+        return 0.0;
+    }
+    double withdrawn = std::min(requestedAmount, it->second);
+    it->second -= withdrawn;
+    if (it->second <= 0.01) {
+        sharedPools_.erase(it);
+    }
+    return withdrawn;
+}
+
+double AttentionMessageBus::getSharedPoolBalance(const std::string& poolId) const {
+    std::lock_guard<std::mutex> lock(busMutex_);
+    auto it = sharedPools_.find(poolId);
+    return (it != sharedPools_.end()) ? it->second : 0.0;
+}
+
+// ============================================================================
+// Phase 1.3: EnhancedAttentionAllocator Implementation
+// ============================================================================
+
+EnhancedAttentionAllocator::EnhancedAttentionAllocator(const std::string& agentId, 
+                                                       double initialBudget)
+    : AttentionAllocator()
+    , agentId_(agentId)
+    , saliencyDetector_(std::make_unique<SaliencyDetector>())
+    , costBudget_(std::make_unique<AttentionCostBudget>(initialBudget))
+    , patternLearner_(std::make_unique<AttentionPatternLearner>())
+    , transferProtocol_(std::make_unique<AttentionTransferProtocol>(agentId)) {}
+
+void EnhancedAttentionAllocator::updateTemporalAttention(const UUID& elementId, 
+                                                         const Timestamp& eventTime) {
+    std::lock_guard<std::mutex> lock(enhancedMutex_);
+    
+    auto it = temporalWindows_.find(elementId);
+    if (it == temporalWindows_.end()) {
+        temporalWindows_[elementId] = TemporalAttentionWindow{};
+        temporalWindows_[elementId].windowStart = std::chrono::system_clock::now();
+    }
+    
+    temporalWindows_[elementId].updateFromEvent(eventTime);
+}
+
+TemporalAttentionWindow EnhancedAttentionAllocator::getTemporalWindow(
+    const UUID& elementId) const {
+    
+    std::lock_guard<std::mutex> lock(enhancedMutex_);
+    
+    auto it = temporalWindows_.find(elementId);
+    if (it != temporalWindows_.end()) {
+        return it->second;
+    }
+    
+    return TemporalAttentionWindow{};
+}
+
+void EnhancedAttentionAllocator::decayAllTemporalWindows() {
+    std::lock_guard<std::mutex> lock(enhancedMutex_);
+    
+    for (auto& [id, window] : temporalWindows_) {
+        window.decay();
+    }
+}
+
+void EnhancedAttentionAllocator::enableSaliencyShifting(bool enable) {
+    saliencyShiftingEnabled_ = enable;
+}
+
+std::vector<UUID> EnhancedAttentionAllocator::computeSaliencyBasedShifts(
+    const std::vector<std::pair<UUID, std::string>>& candidates) {
+    
+    if (!saliencyShiftingEnabled_ || !saliencyDetector_) {
+        return {};
+    }
+    
+    std::vector<std::pair<UUID, SaliencyDetector::SaliencyFeatures>> saliencyCandidates;
+    
+    for (const auto& [id, content] : candidates) {
+        auto features = saliencyDetector_->calculateSaliency(content);
+        saliencyCandidates.emplace_back(id, features);
+    }
+    
+    // Get current attention values
+    std::unordered_map<UUID, AttentionValue> currentAttention;
+    for (const auto& [id, content] : candidates) {
+        currentAttention[id] = getAttentionValue(id);
+    }
+    
+    return saliencyDetector_->identifyAttentionShiftTargets(currentAttention, saliencyCandidates);
+}
+
+AttentionCostBudget::AllocationResult EnhancedAttentionAllocator::allocateWithCost(
+    const UUID& targetId, double amount, double priority) {
+    
+    if (!costBudget_) {
+        AttentionCostBudget::AllocationResult result;
+        result.success = false;
+        result.reason = "Budget system not initialized";
+        return result;
+    }
+    
+    AttentionCostBudget::AllocationRequest request;
+    request.targetId = targetId;
+    request.requestedAmount = amount;
+    request.priority = priority;
+    request.canPartialAllocate = true;
+    
+    auto result = costBudget_->requestAllocation(request);
+    
+    if (result.success) {
+        // Update attention value
+        AttentionValue current = getAttentionValue(targetId);
+        current.setSTI(std::min(current.sti() + result.allocatedAmount * 0.1, MAX_STI));
+        updateAttentionValue(targetId, current);
+    }
+    
+    return result;
+}
+
+void EnhancedAttentionAllocator::tickBudget(double deltaSeconds) {
+    if (costBudget_) {
+        costBudget_->tick(deltaSeconds);
+    }
+}
+
+void EnhancedAttentionAllocator::enablePatternLearning(bool enable) {
+    patternLearningEnabled_ = enable;
+}
+
+void EnhancedAttentionAllocator::recordAttentionEvent(
+    const AttentionPatternLearner::AttentionEvent& event) {
+    
+    if (patternLearningEnabled_ && patternLearner_) {
+        patternLearner_->recordEvent(event);
+    }
+}
+
+std::vector<std::pair<UUID, double>> EnhancedAttentionAllocator::getPredictedNeeds() {
+    if (!patternLearningEnabled_ || !patternLearner_) {
+        return {};
+    }
+    
+    // Learn patterns first
+    patternLearner_->learnPatterns();
+    
+    // Get predictions with empty context (could be enhanced with actual context)
+    std::unordered_map<std::string, std::string> context;
+    return patternLearner_->predictAttentionNeeds(context);
+}
+
+void EnhancedAttentionAllocator::enableInterAgentTransfer(bool enable) {
+    interAgentTransferEnabled_ = enable;
+}
+
+AttentionTransferProtocol& EnhancedAttentionAllocator::getTransferProtocol() {
+    return *transferProtocol_;
+}
+
+double EnhancedAttentionAllocator::getEnhancedAttentionScore(const UUID& elementId) const {
+    std::lock_guard<std::mutex> lock(enhancedMutex_);
+    
+    // Base attention
+    AttentionValue base = getAttentionValue(elementId);
+    double baseScore = (base.sti() / MAX_STI) * 0.5 + (base.lti() / MAX_LTI) * 0.3;
+    
+    // Temporal component
+    double temporalScore = 0.0;
+    auto temporalIt = temporalWindows_.find(elementId);
+    if (temporalIt != temporalWindows_.end()) {
+        temporalScore = temporalIt->second.getCompositeAttention() * 0.2;
+    }
+    
+    return std::min(1.0, baseScore + temporalScore);
+}
+
+EnhancedAttentionAllocator::EnhancedStatistics 
+EnhancedAttentionAllocator::getEnhancedStatistics() const {
+    
+    std::lock_guard<std::mutex> lock(enhancedMutex_);
+    
+    EnhancedStatistics stats;
+    stats.base = getStatistics();
+    
+    // Calculate average temporal score
+    if (!temporalWindows_.empty()) {
+        double totalTemporal = 0.0;
+        for (const auto& [id, window] : temporalWindows_) {
+            totalTemporal += window.getCompositeAttention();
+        }
+        stats.averageTemporalScore = totalTemporal / temporalWindows_.size();
+    }
+    
+    // Budget utilization
+    if (costBudget_) {
+        stats.budgetUtilization = 1.0 - (costBudget_->getAvailableBudget() / 
+                                          costBudget_->getTotalBudget());
+    }
+    
+    // Pattern count
+    if (patternLearner_) {
+        stats.patternsPredicted = static_cast<int>(patternLearner_->getPatterns().size());
+    }
+    
+    // Active transfers
+    if (transferProtocol_) {
+        stats.activeTransfers = static_cast<int>(transferProtocol_->getActiveTransfers().size());
+    }
+    
+    return stats;
+}
+
+// ============================================================================
+// Phase 1.3: AttentionAwareMemoryManager Enhanced Methods
+// ============================================================================
+
+std::shared_ptr<EnhancedAttentionAllocator> 
+AttentionAwareMemoryManager::getEnhancedAllocator() const {
+    return enhancedAllocator_;
+}
+
+void AttentionAwareMemoryManager::enableEnhancedAttention(const std::string& agentId) {
+    if (!enhancedAllocator_) {
+        enhancedAllocator_ = std::make_shared<EnhancedAttentionAllocator>(agentId);
+    }
+}
+
+// ============================================================================
+// Phase 1.3: Enhanced Convenience Functions
+// ============================================================================
+
+namespace attention {
+
+void enableEnhanced(const std::string& agentId) {
+    getGlobalAttentionAwareMemoryManager().enableEnhancedAttention(agentId);
+}
+
+double getEnhancedScore(const UUID& elementId) {
+    auto enhanced = getGlobalAttentionAwareMemoryManager().getEnhancedAllocator();
+    if (enhanced) {
+        return enhanced->getEnhancedAttentionScore(elementId);
+    }
+    return 0.0;
+}
+
+std::vector<std::pair<UUID, double>> predictNeeds() {
+    auto enhanced = getGlobalAttentionAwareMemoryManager().getEnhancedAllocator();
+    if (enhanced) {
+        return enhanced->getPredictedNeeds();
+    }
+    return {};
+}
+
+void recordEvent(const std::string& category, const UUID& targetId, double level) {
+    auto enhanced = getGlobalAttentionAwareMemoryManager().getEnhancedAllocator();
+    if (enhanced) {
+        AttentionPatternLearner::AttentionEvent event;
+        event.targetId = targetId;
+        event.category = category;
+        event.attentionLevel = level;
+        event.timestamp = std::chrono::system_clock::now();
+        enhanced->recordAttentionEvent(event);
+    }
+}
+
+} // namespace attention
 
 } // namespace elizaos

--- a/cpp/packages/core/core/src/core.cpp
+++ b/cpp/packages/core/core/src/core.cpp
@@ -4,6 +4,7 @@
 #include <iomanip>
 #include <algorithm>
 #include <cmath>
+#include <cctype>
 
 namespace elizaos {
 
@@ -111,6 +112,56 @@ void State::addActor(const Actor& actor) {
 
 void State::addGoal(const Goal& goal) {
     goals_.push_back(goal);
+}
+
+namespace {
+// Case-insensitive ASCII equality used by the goal-status helpers so that
+// callers can match "Active"/"active"/"ACTIVE" interchangeably.
+bool iequalsAsciiGoalStatus(const std::string& a, const std::string& b) {
+    if (a.size() != b.size()) {
+        return false;
+    }
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        if (std::tolower(static_cast<unsigned char>(a[i])) !=
+            std::tolower(static_cast<unsigned char>(b[i]))) {
+            return false;
+        }
+    }
+    return true;
+}
+} // namespace
+
+bool State::updateGoalStatus(const UUID& goalId, const std::string& status) {
+    for (auto& goal : goals_) {
+        if (goal.id == goalId) {
+            goal.status = status;
+            goal.updatedAt = std::chrono::system_clock::now();
+            return true;
+        }
+    }
+    return false;
+}
+
+bool State::updateGoalStatusByDescription(const std::string& description,
+                                          const std::string& status) {
+    for (auto& goal : goals_) {
+        if (iequalsAsciiGoalStatus(goal.description, description)) {
+            goal.status = status;
+            goal.updatedAt = std::chrono::system_clock::now();
+            return true;
+        }
+    }
+    return false;
+}
+
+std::size_t State::countGoalsWithStatus(const std::string& status) const {
+    std::size_t count = 0;
+    for (const auto& goal : goals_) {
+        if (iequalsAsciiGoalStatus(goal.status, status)) {
+            ++count;
+        }
+    }
+    return count;
 }
 
 void State::addRecentMessage(std::shared_ptr<Memory> memory) {

--- a/cpp/packages/integration/autonomous_starter/CMakeLists.txt
+++ b/cpp/packages/integration/autonomous_starter/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(elizaos-autonomous_starter
     elizaos-agentloop
     elizaos-agentshell
     elizaos-agentlogger
+    elizaos-agentmemory
     Threads::Threads
 )
 
@@ -32,6 +33,7 @@ target_link_libraries(autonomous_starter_demo
     elizaos-agentloop
     elizaos-agentshell
     elizaos-agentlogger
+    elizaos-agentmemory
     Threads::Threads
 )
 
@@ -51,6 +53,7 @@ target_link_libraries(autonomous_starter_tests
     elizaos-agentloop
     elizaos-agentshell
     elizaos-agentlogger
+    elizaos-agentmemory
     gtest_main
     Threads::Threads
 )

--- a/cpp/packages/integration/autonomous_starter/src/autonomous_starter.cpp
+++ b/cpp/packages/integration/autonomous_starter/src/autonomous_starter.cpp
@@ -1,5 +1,8 @@
 #include "elizaos/autonomous_starter.hpp"
 #include "elizaos/agentlogger.hpp"
+#include "elizaos/attention.hpp"
+
+#include <cmath>
 
 #include <algorithm>
 #include <array>
@@ -13,12 +16,17 @@
 #include <sstream>
 #include <thread>
 #include <vector>
+#include <unordered_map>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <direct.h>  // _getcwd on Windows
 #define getcwd _getcwd
+#ifndef _MSC_VER
+// MinGW has popen/pclose without underscore prefix.
+#else
 #define popen _popen
 #define pclose _pclose
+#endif
 #else
 #include <sys/wait.h>
 #include <unistd.h>
@@ -49,7 +57,6 @@ std::string normalizeCommandForSafety(const std::string& command) {
             c = ' ';
         }
     }
-
     std::string collapsed;
     collapsed.reserve(normalized.size());
     bool previousSpace = false;
@@ -131,7 +138,8 @@ std::string shellQuote(const std::string& value) {
 }
 
 int decodeExitStatus(int rawStatus) {
-#ifdef _MSC_VER
+#ifdef _WIN32
+    // On Windows, pclose() returns the process exit code directly.
     return rawStatus;
 #else
     if (rawStatus == -1) {
@@ -282,14 +290,315 @@ std::string AutonomousStarter::selectGoalContext() const {
         return status;
     };
 
-    for (const auto& goal : goals) {
-        const auto status = normalizeStatus(goal.status);
-        if (status == "active" || status == "in_progress" || status == "pending") {
-            return goal.description.empty() ? "continue open autonomy goal" : goal.description;
+    // Prefer the currently pursued goal so perception, reasoning, and action all
+    // converge on the same intent within a cycle.
+    if (!activeGoalId_.empty()) {
+        for (const auto& goal : goals) {
+            if (goal.id == activeGoalId_) {
+                const auto status = normalizeStatus(goal.status);
+                if (status == "active" || status == "in_progress" || status == "pending") {
+                    return goal.description.empty() ? "continue open autonomy goal" : goal.description;
+                }
+            }
+        }
+    }
+
+    // Priority order: active > in_progress > pending.
+    for (const char* wanted : {"active", "in_progress", "pending"}) {
+        for (const auto& goal : goals) {
+            if (normalizeStatus(goal.status) == wanted) {
+                return goal.description.empty() ? "continue open autonomy goal" : goal.description;
+            }
         }
     }
 
     return goals.back().description.empty() ? "review completed autonomy context" : goals.back().description;
+}
+
+const StateGoal* AutonomousStarter::selectActiveGoal() {
+    const auto& goals = state_.getGoals();
+    auto normalizeStatus = [](std::string status) {
+        std::transform(status.begin(), status.end(), status.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return status;
+    };
+
+    // Promote the first pending goal to active when no active goal exists, so
+    // the agent always has exactly one goal in flight (single-tasking autonomy).
+    const StateGoal* active = nullptr;
+    const StateGoal* firstPending = nullptr;
+    for (const auto& goal : goals) {
+        const auto status = normalizeStatus(goal.status);
+        if ((status == "active" || status == "in_progress") && active == nullptr) {
+            active = &goal;
+        } else if (status == "pending" && firstPending == nullptr) {
+            firstPending = &goal;
+        }
+    }
+
+    if (active == nullptr && firstPending != nullptr) {
+        state_.updateGoalStatus(firstPending->id, "active");
+        // Re-resolve the pointer after mutation (vector storage is stable here,
+        // but re-scan defensively in case of future reallocation semantics).
+        for (const auto& goal : state_.getGoals()) {
+            if (goal.id == firstPending->id) {
+                active = &goal;
+                break;
+            }
+        }
+    }
+
+    if (active != nullptr) {
+        activeGoalId_ = active->id;
+    } else {
+        activeGoalId_ = "";
+    }
+    return active;
+}
+
+bool AutonomousStarter::planSatisfiesGoal(const StateGoal& goal,
+                                          const std::string& plan,
+                                          const ShellCommandResult& result) const {
+    // A goal is only satisfied by a successful action whose plan is topically
+    // aligned with the goal. Failed commands never satisfy a goal, so the agent
+    // will keep working (or escalate via the stagnation guard) until it produces
+    // real evidence. This is the behavioral consequence that makes the goal
+    // center "living" rather than a decorative status field.
+    if (!result.success) {
+        return false;
+    }
+
+    const std::string goalText = toLowerAscii(goal.description);
+    const std::string planText = toLowerAscii(plan);
+
+    auto mentions = [](const std::string& text, std::initializer_list<const char*> needles) {
+        for (const char* needle : needles) {
+            if (text.find(needle) != std::string::npos) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // Situational-awareness goals are satisfied by any successful awareness plan.
+    if (mentions(goalText, {"situational awareness", "workspace", "awareness"})) {
+        return mentions(planText, {"situational awareness", "workspace", "awareness", "pwd", "directory"});
+    }
+    // Project-structure / source-inspection goals.
+    if (mentions(goalText, {"project structure", "c++", "source", "cmake", "code actions"})) {
+        return mentions(planText, {"project structure", "source", "c++", "cmake", "repository source"});
+    }
+    // Test/validation goals.
+    if (mentions(goalText, {"test", "validation", "self-audit"})) {
+        return mentions(planText, {"test", "validation", "self-audit"});
+    }
+    // Runtime/system goals.
+    if (mentions(goalText, {"runtime", "system", "kernel", "identity"})) {
+        return mentions(planText, {"runtime", "system", "kernel", "identity"});
+    }
+
+    // Generic exploration goals are satisfied by any successful action.
+    return true;
+}
+
+bool AutonomousStarter::planSatisfiesGoalTopic(const std::string& normalizedGoal,
+                                               const std::string& plan) const {
+    const std::string goalText = normalizedGoal;  // caller passes lower-cased goal
+    const std::string planText = toLowerAscii(plan);
+
+    auto mentions = [](const std::string& text, std::initializer_list<const char*> needles) {
+        for (const char* needle : needles) {
+            if (text.find(needle) != std::string::npos) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // Mirror the topic mapping used by planSatisfiesGoal(), minus the success
+    // requirement. This keeps the stagnation-guard exemption in lock-step with
+    // the goal-completion alignment logic so the two never disagree about whether
+    // a plan serves a goal.
+    if (mentions(goalText, {"situational awareness", "workspace", "awareness"})) {
+        return mentions(planText, {"situational awareness", "workspace", "awareness", "pwd", "directory"});
+    }
+    if (mentions(goalText, {"project structure", "c++", "source", "cmake", "code actions"})) {
+        return mentions(planText, {"project structure", "source", "c++", "cmake", "repository source"});
+    }
+    if (mentions(goalText, {"test", "validation", "self-audit", "audit"})) {
+        return mentions(planText, {"test", "validation", "self-audit"});
+    }
+    if (mentions(goalText, {"runtime", "system", "kernel", "identity"})) {
+        return mentions(planText, {"runtime", "system", "kernel", "identity"});
+    }
+    // For generic goals no specific plan is privileged, so repetition of any plan
+    // is treated as aimless and remains subject to the stagnation guard.
+    return false;
+}
+
+void AutonomousStarter::seedAdaptiveGoal() {
+    const Timestamp now = std::chrono::system_clock::now();
+    static const std::array<const char*, 3> rotations = {{
+        "Sample repository source files to deepen project understanding",
+        "Self-audit test and validation surfaces for autonomy health",
+        "Inspect system identity and runtime context for situational grounding"
+    }};
+    const std::string description = rotations[adaptiveGoalCounter_ % rotations.size()];
+    ++adaptiveGoalCounter_;
+    state_.addGoal(StateGoal{
+        generateUUID(),
+        description,
+        "pending",
+        now,
+        now
+    });
+    appendMemory("Adaptive goal seeded: " + description +
+                 " (all prior goals satisfied; autonomy continues exploring).");
+}
+
+void AutonomousStarter::evaluateGoalProgress(const std::string& plan,
+                                             const std::string& command,
+                                             const ShellCommandResult& result) {
+    (void)command;
+
+    // Mark the active goal completed when the successful action provides aligned
+    // evidence, then promote the next pending goal.
+    if (!activeGoalId_.empty()) {
+        const StateGoal* activeGoal = nullptr;
+        for (const auto& goal : state_.getGoals()) {
+            if (goal.id == activeGoalId_) {
+                activeGoal = &goal;
+                break;
+            }
+        }
+        // Convergence gate: a single aligned success is only a probe, not proof
+        // that the goal is achieved. Require the serving plan to have demonstrated
+        // *reliable* success (>= 2 attempts and a success ratio >= 0.5) before
+        // marking the goal completed. This keeps a sustained goal live across the
+        // first cycle or two -- preserving plan continuity for a single dominant
+        // goal -- while still driving every goal to closed-loop completion within
+        // a handful of cycles. The threshold mirrors advanceGoalLifecycle() so the
+        // two evidence-gated paths agree on what "reliable" means.
+        // A goal is "achieved" only after its serving plan has produced reliable,
+        // repeated evidence: at least three successful aligned attempts with a
+        // success ratio >= 0.5. Three (rather than two) gives a lone dominant goal
+        // a stable multi-cycle pursuit window before it converges, while a set of
+        // goals still drives every member to completion well within a normal run.
+        const bool planIsReliable =
+            planStats_[plan].attempts >= 3 && getPlanSuccessRatio(plan) >= 0.5;
+        if (activeGoal != nullptr && planSatisfiesGoal(*activeGoal, plan, result) &&
+            planIsReliable) {
+            const std::string completedDescription = activeGoal->description;
+            state_.updateGoalStatus(activeGoalId_, "completed");
+            appendMemory("Goal completed: " + completedDescription +
+                         " (satisfied by reliable plan='" + plan + "').");
+            activeGoalId_ = "";
+        }
+    }
+
+    // If every goal is now complete, seed a fresh adaptive goal so the agent
+    // never dead-ends into a no-open-goal idle loop.
+    if (getOpenGoalCount() == 0) {
+        seedAdaptiveGoal();
+    }
+}
+
+std::size_t AutonomousStarter::getOpenGoalCount() const {
+    std::size_t open = 0;
+    for (const auto& goal : state_.getGoals()) {
+        std::string status = toLowerAscii(goal.status);
+        if (status == "active" || status == "in_progress" || status == "pending") {
+            ++open;
+        }
+    }
+    return open;
+}
+
+std::size_t AutonomousStarter::getCompletedGoalCount() const {
+    std::size_t completed = 0;
+    for (const auto& goal : state_.getGoals()) {
+        if (toLowerAscii(goal.status) == "completed") {
+            ++completed;
+        }
+    }
+    return completed;
+}
+
+std::string AutonomousStarter::scoreAndSelectGoal() const {
+    const auto& goals = state_.getGoals();
+    if (goals.empty()) {
+        return selectGoalContext();
+    }
+
+    auto normalizeStatus = [](std::string status) {
+        std::transform(status.begin(), status.end(), status.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return status;
+    };
+
+    // Score each open goal through the repository's AttentionAllocator. Open
+    // goals (active/in_progress/pending) receive higher urgency; freshly created
+    // goals (small index) receive higher novelty; long-standing goals accrue
+    // importance. This replaces ad-hoc string matching with the engine's own
+    // ECAN-style composite attention scoring.
+    std::vector<UUID> candidateIds;
+    candidateIds.reserve(goals.size());
+    const Timestamp now = std::chrono::system_clock::now();
+
+    for (std::size_t i = 0; i < goals.size(); ++i) {
+        const auto& goal = goals[i];
+        const std::string status = normalizeStatus(goal.status);
+        const bool isOpen = (status == "active" || status == "in_progress" || status == "pending");
+        if (!isOpen) {
+            continue;
+        }
+
+        AttentionValue av;
+        // Urgency: active goals outrank pending goals.
+        av.urgency = (status == "active" || status == "in_progress") ? 0.85 : 0.55;
+        // Importance: older goals (earlier in the list / earlier createdAt) carry
+        // more long-term importance because they anchor the agent's mission.
+        const double ageSeconds =
+            std::chrono::duration_cast<std::chrono::seconds>(now - goal.createdAt).count();
+        av.importance = std::min(1.0, 0.4 + (ageSeconds / 3600.0) * 0.1);
+        // Novelty: goals not yet attempted (no matching memory) are novel.
+        const std::string needle = goal.description.substr(0, std::min<std::size_t>(goal.description.size(), 24));
+        bool seen = false;
+        for (const auto& mem : state_.getRecentMessages()) {
+            if (mem && !needle.empty() && mem->getContent().find(needle) != std::string::npos) {
+                seen = true;
+                break;
+            }
+        }
+        av.novelty = seen ? 0.2 : 0.8;
+        // Activation: bias by current competence so a struggling agent focuses on
+        // the highest-urgency goal rather than exploring novel ones.
+        av.activation = competenceSignal_;
+
+        goalAttention_.updateAttentionValue(goal.id, av);
+        candidateIds.push_back(goal.id);
+    }
+
+    if (candidateIds.empty()) {
+        return selectGoalContext();
+    }
+
+    const auto prioritized = goalAttention_.prioritizeElements(candidateIds);
+    if (prioritized.empty()) {
+        return selectGoalContext();
+    }
+
+    const UUID topId = prioritized.front().elementId;
+    for (const auto& goal : goals) {
+        if (goal.id == topId) {
+            return goal.description.empty() ? selectGoalContext() : goal.description;
+        }
+    }
+    return selectGoalContext();
+}
+
+std::string AutonomousStarter::getAttentionPrioritizedGoal() const {
+    return scoreAndSelectGoal();
 }
 
 std::string AutonomousStarter::buildActionCommandForPlan(const std::string& plan) const {
@@ -492,6 +801,9 @@ void AutonomousStarter::startAutonomousLoop() {
         }),
         LoopStep([this](std::shared_ptr<void> input) -> std::shared_ptr<void> {
             return actionStep(input);
+        }),
+        LoopStep([this](std::shared_ptr<void> input) -> std::shared_ptr<void> {
+            return reflectionStep(input);
         })
     };
 
@@ -534,12 +846,176 @@ std::size_t AutonomousStarter::runCognitiveCycleOnce() {
     std::shared_ptr<void> token = std::make_shared<int>(0);
     token = perceptionStep(token);
     token = reasoningStep(token);
-    actionStep(token);
+    token = actionStep(token);
+    reflectionStep(token);
     return cognitiveCycle_;
+}
+
+double AutonomousStarter::getPlanSuccessRatio(const std::string& plan) const {
+    auto it = planStats_.find(plan);
+    if (it == planStats_.end() || it->second.attempts == 0) {
+        return 0.0;
+    }
+    return static_cast<double>(it->second.successes) /
+           static_cast<double>(it->second.attempts);
+}
+
+double AutonomousStarter::planBias(const std::string& plan) const {
+    // Optimistic prior: unseen plans start neutral so the agent still explores,
+    // while plans with a track record are biased by their measured success rate.
+    auto it = planStats_.find(plan);
+    if (it == planStats_.end() || it->second.attempts == 0) {
+        return 0.5;
+    }
+    return static_cast<double>(it->second.successes) /
+           static_cast<double>(it->second.attempts);
+}
+
+void AutonomousStarter::recordPlanOutcome(const std::string& plan, bool success) {
+    if (plan.empty()) {
+        return;
+    }
+    auto& stats = planStats_[plan];
+    ++stats.attempts;
+    if (success) {
+        ++stats.successes;
+    }
+}
+
+void AutonomousStarter::refreshGoalAttention() {
+    const auto& goals = state_.getGoals();
+    for (const auto& goal : goals) {
+        std::string status = goal.status;
+        std::transform(status.begin(), status.end(), status.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        const bool open = (status == "active" || status == "in_progress" ||
+                           status == "pending");
+
+        AttentionValue av = goalAttention_.hasAttentionValue(goal.id)
+                                ? goalAttention_.getAttentionValue(goal.id)
+                                : AttentionValue{};
+        // Importance: active goals outrank pending; completed goals fade out.
+        if (status == "active" || status == "in_progress") {
+            av.importance = 0.9;
+            av.urgency = 0.7;
+        } else if (status == "pending") {
+            av.importance = 0.6;
+            av.urgency = 0.5;
+        } else {
+            av.importance = 0.1;
+            av.urgency = 0.1;
+        }
+        // Novelty rewards goals the agent has not focused on recently.
+        av.novelty = (goal.id == focusedGoalId_) ? std::max(0.0, av.novelty * 0.6)
+                                                 : std::min(1.0, av.novelty + 0.3);
+        av.activation = open ? std::min(1.0, av.activation + 0.2)
+                             : std::max(0.0, av.activation * 0.5);
+        goalAttention_.updateAttentionValue(goal.id, av);
+    }
+}
+
+const StateGoal* AutonomousStarter::selectFocusGoal() {
+    const auto& goals = state_.getGoals();
+    if (goals.empty()) {
+        focusedGoalId_.clear();
+        return nullptr;
+    }
+    refreshGoalAttention();
+
+    const StateGoal* best = nullptr;
+    double bestScore = -1.0;
+    for (const auto& goal : goals) {
+        std::string status = goal.status;
+        std::transform(status.begin(), status.end(), status.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (status != "active" && status != "in_progress" && status != "pending") {
+            continue;
+        }
+        const double score =
+            goalAttention_.getAttentionValue(goal.id).getCompositeScore();
+        if (score > bestScore) {
+            bestScore = score;
+            best = &goal;
+        }
+    }
+    if (!best) {
+        best = &goals.back();  // all goals completed: keep most recent context
+    }
+    focusedGoalId_ = best->id;
+    return best;
+}
+
+void AutonomousStarter::advanceGoalLifecycle(const std::string& plan, bool actionSucceeded) {
+    if (focusedGoalId_.empty() || !actionSucceeded) {
+        return;
+    }
+    // Find the focused goal's current status.
+    std::string currentStatus;
+    for (const auto& goal : state_.getGoals()) {
+        if (goal.id == focusedGoalId_) {
+            currentStatus = goal.status;
+            break;
+        }
+    }
+    std::string lower = currentStatus;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    // pending -> active on first successful action toward the goal; active ->
+    // completed once the agent has accumulated enough successful experience on
+    // its plan for that goal.
+    if (lower == "pending") {
+        state_.updateGoalStatus(focusedGoalId_, "active");
+        appendMemory("Goal lifecycle: goal " + focusedGoalId_ +
+                     " advanced pending -> active after successful plan '" + plan + "'.");
+    } else if (lower == "active" || lower == "in_progress") {
+        if (getPlanSuccessRatio(plan) >= 0.5 &&
+            planStats_[plan].attempts >= 3) {
+            // Capture the description before mutation so the completion evidence
+            // token matches the one evaluateGoalProgress emits (single vocabulary
+            // for supervisors/tests scanning memory for "Goal completed:").
+            std::string completedDescription;
+            for (const auto& goal : state_.getGoals()) {
+                if (goal.id == focusedGoalId_) {
+                    completedDescription = goal.description;
+                    break;
+                }
+            }
+            state_.updateGoalStatus(focusedGoalId_, "completed");
+            appendMemory("Goal lifecycle: goal " + focusedGoalId_ +
+                         " advanced active -> completed after reliable plan '" + plan + "'.");
+            if (!completedDescription.empty()) {
+                appendMemory("Goal completed: " + completedDescription +
+                             " (satisfied by reliable plan='" + plan + "').");
+            }
+            // Invariant repair: the active-goal pointer must never name a completed
+            // goal. If the focused goal we just completed is also the currently
+            // pursued active goal, clear the pointer immediately in the same step
+            // so getActiveGoalId() only ever references an open goal. The next
+            // perception step's selectActiveGoal() promotes the next pending goal.
+            if (activeGoalId_ == focusedGoalId_) {
+                activeGoalId_ = "";
+            }
+            // NOTE: adaptive re-seeding is intentionally NOT done here. It is owned
+            // by evaluateGoalProgress(), which runs in the ACTION phase -- before
+            // reflection and, crucially, after the current cycle's reasoning has
+            // already chosen its plan. Seeding a fresh driver here (in reflection)
+            // would swap the agent's objective mid-window and pull a sustained
+            // dominant goal's plan off-topic on the very next cycle. Deferring to
+            // the action-phase re-seed keeps a lone completed goal as the fallback
+            // focus context (selectFocusGoal returns goals.back()), so reasoning
+            // continues to serve its topic until a genuinely new open goal exists.
+        }
+    }
 }
 
 std::shared_ptr<void> AutonomousStarter::perceptionStep(std::shared_ptr<void> input) {
     ++cognitiveCycle_;
+
+    // Resolve which goal we are pursuing this cycle (promotes a pending goal to
+    // active if nothing is active), so the whole observe-reason-act pass is
+    // anchored to a single concrete intent.
+    selectActiveGoal();
 
     const auto pwd = executeShellCommand("pwd");
     const auto listing = executeShellCommand("ls -1 | head -20");
@@ -568,38 +1044,168 @@ std::shared_ptr<void> AutonomousStarter::perceptionStep(std::shared_ptr<void> in
 
 std::shared_ptr<void> AutonomousStarter::reasoningStep(std::shared_ptr<void> input) {
     const std::size_t memoryCount = state_.getRecentMessages().size();
-    const std::string goalContext = selectGoalContext();
+
+    // Attention-weighted goal selection: focus on the highest-scoring open goal
+    // rather than the first active one. This makes the agent's attention an
+    // economic resource that shifts toward important/urgent/novel goals.
+    const StateGoal* focus = selectFocusGoal();
+    const std::string goalContext = focus ? (focus->description.empty()
+                                                 ? selectGoalContext()
+                                                 : focus->description)
+                                          : selectGoalContext();
     std::string normalizedGoal = goalContext;
     std::transform(normalizedGoal.begin(), normalizedGoal.end(), normalizedGoal.begin(),
                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
 
-    if (normalizedGoal.find("test") != std::string::npos ||
+    // Plan selection is goal-first: the plan must serve the goal the agent is
+    // actively pursuing, otherwise action evidence can never satisfy that goal
+    // and the closed loop cannot converge. Topic precedence is therefore keyed on
+    // the active goal's description, with environmental hints used only as a
+    // tie-breaker for goals that are themselves about project structure.
+    if (normalizedGoal.find("situational awareness") != std::string::npos ||
+        normalizedGoal.find("workspace") != std::string::npos ||
+        normalizedGoal.find("awareness") != std::string::npos) {
+        lastPlan_ = "establish situational awareness with pwd and directory inspection";
+    } else if (normalizedGoal.find("test") != std::string::npos ||
         normalizedGoal.find("validation") != std::string::npos ||
-        normalizedGoal.find("self-audit") != std::string::npos ||
-        normalizedGoal.find("audit") != std::string::npos) {
-        lastPlan_ = "run autonomy self-audit by inspecting tests and validation coverage";
+        normalizedGoal.find("self-audit") != std::string::npos) {
+        lastPlan_ = "self-audit validation and test surfaces";
     } else if (normalizedGoal.find("c++") != std::string::npos ||
                normalizedGoal.find("project structure") != std::string::npos ||
-               lastObservationSummary_.find("CMakeLists.txt") != std::string::npos) {
+               normalizedGoal.find("source") != std::string::npos ||
+               normalizedGoal.find("code actions") != std::string::npos) {
         lastPlan_ = "inspect C++ project structure with targeted source discovery";
     } else if (normalizedGoal.find("runtime") != std::string::npos ||
-               normalizedGoal.find("system") != std::string::npos) {
+               normalizedGoal.find("system") != std::string::npos ||
+               normalizedGoal.find("identity") != std::string::npos ||
+               normalizedGoal.find("kernel") != std::string::npos) {
         lastPlan_ = "inspect system identity and runtime context";
-    } else if (memoryCount < 5 || normalizedGoal.find("situational awareness") != std::string::npos ||
-               normalizedGoal.find("workspace") != std::string::npos) {
+    } else if (memoryCount < 5) {
         lastPlan_ = "establish situational awareness with pwd and directory inspection";
-    } else if (actionCounter_ % 3 == 0) {
+    } else if (actionCounter_ % 4 == 0) {
         lastPlan_ = "sample repository source files";
-    } else if (actionCounter_ % 3 == 1) {
+    } else if (actionCounter_ % 4 == 1) {
+        lastPlan_ = "self-audit validation and test surfaces";
+    } else if (actionCounter_ % 4 == 2) {
         lastPlan_ = "inspect system identity and kernel context";
     } else {
         lastPlan_ = "maintain lightweight environmental awareness";
     }
 
+    // Build the candidate plan set implied by the focused goal/context.
+    std::vector<std::string> candidatePlans;
+    // Closed-loop feedback: if the previous actions have been failing, do not
+    // keep selecting the same plan. Fall back to the safest situational-
+    // awareness plan to recover ground truth before attempting richer actions.
+    std::size_t recentFailures = 0;
+    for (bool ok : recentActionOutcomes_) {
+        if (!ok) ++recentFailures;
+    }
+    const bool strugglingNow = (recentActionOutcomes_.size() >= 2 && recentFailures >= 2);
+
+    if (strugglingNow) {
+        lastPlan_ = "establish situational awareness with pwd and directory inspection";
+        appendMemory("Cycle " + std::to_string(cognitiveCycle_) +
+                     " reasoning: goal = " + goalContext +
+                     "; recent experience summary = " + summarizeRecentExperience() +
+                     "; competence = " + std::to_string(competenceSignal_) +
+                     "; detected repeated action failure, falling back to safe situational awareness" +
+                     "; selected plan = " + lastPlan_ + ".");
+        logInfo("Reasoning detected repeated failure; fallback plan: " + lastPlan_);
+        return input;
+    }
+
+    if (normalizedGoal.find("test") != std::string::npos ||
+        normalizedGoal.find("validation") != std::string::npos ||
+        normalizedGoal.find("self-audit") != std::string::npos) {
+        candidatePlans.push_back("self-audit validation and test surfaces");
+    }
+    if (normalizedGoal.find("c++") != std::string::npos ||
+        normalizedGoal.find("project structure") != std::string::npos ||
+        lastObservationSummary_.find("CMakeLists.txt") != std::string::npos) {
+        candidatePlans.push_back("inspect C++ project structure with targeted source discovery");
+    }
+    if (normalizedGoal.find("runtime") != std::string::npos ||
+        normalizedGoal.find("system") != std::string::npos) {
+        candidatePlans.push_back("inspect system identity and runtime context");
+    }
+    if (memoryCount < 5 || normalizedGoal.find("situational awareness") != std::string::npos ||
+        normalizedGoal.find("workspace") != std::string::npos) {
+        candidatePlans.push_back("establish situational awareness with pwd and directory inspection");
+    }
+    // Always include the rotating exploratory plans so the agent keeps options
+    // open even once core goals are addressed.
+    candidatePlans.push_back("sample repository source files");
+    candidatePlans.push_back("inspect system identity and kernel context");
+    candidatePlans.push_back("maintain lightweight environmental awareness");
+
+    // Outcome-based plan adaptation: pick the candidate with the highest learned
+    // success bias. Ties are broken by candidate order (goal-relevant plans are
+    // listed first), which preserves the previous deterministic preference while
+    // letting accumulated feedback override it once evidence exists.
+    lastPlan_ = candidatePlans.front();
+    double bestBias = -1.0;
+    for (const auto& plan : candidatePlans) {
+        const double bias = planBias(plan);
+        if (bias > bestBias) {
+            bestBias = bias;
+            lastPlan_ = plan;
+        }
+    }
+
+    // Stagnation guard: if reasoning keeps producing the same plan, the agent is
+    // stuck. Count consecutive repeats and, once a threshold is crossed, escalate
+    // to a deliberately different plan so autonomy explores instead of looping.
+    //
+    // Crucial refinement (living-systems principle): purposeful repetition is not
+    // stagnation. When the repeated plan is the one that directly SERVES the
+    // agent's current goal, repeating it is convergence toward that goal, not a
+    // loop the agent is trapped in. Escalating away from a goal-aligned plan would
+    // starve the goal of the very evidence it needs to complete. We therefore
+    // exempt the goal-serving plan from escalation while still counting repeats
+    // (so the bounded-stagnation invariant holds), and only force a different plan
+    // when the repetition is aimless (plan not aligned with the active goal).
+    if (lastPlan_ == previousPlan_) {
+        ++stagnationCounter_;
+    } else {
+        stagnationCounter_ = 0;
+    }
+    const bool planServesCurrentGoal = planSatisfiesGoalTopic(normalizedGoal, lastPlan_);
+    if (stagnationCounter_ >= 2 && !planServesCurrentGoal) {
+        static const std::array<const char*, 4> escalationPlans = {{
+            "sample repository source files",
+            "self-audit validation and test surfaces",
+            "inspect system identity and kernel context",
+            "establish situational awareness with pwd and directory inspection"
+        }};
+        std::string escalated = lastPlan_;
+        for (const char* candidate : escalationPlans) {
+            if (candidate != lastPlan_) {
+                escalated = candidate;
+                break;
+            }
+        }
+        appendMemory("Stagnation detected after " + std::to_string(stagnationCounter_) +
+                     " repeats of plan '" + lastPlan_ + "'; escalating to '" + escalated + "'.");
+        lastPlan_ = escalated;
+        stagnationCounter_ = 0;
+    } else if (stagnationCounter_ >= 2 && planServesCurrentGoal) {
+        // Purposeful repetition: keep pursuing the goal-aligned plan but reset the
+        // counter so the bounded-stagnation invariant (<= 2) is preserved and the
+        // guard remains armed for genuinely aimless loops later.
+        appendMemory("Sustained goal-aligned pursuit of plan '" + lastPlan_ +
+                     "' (convergence, not stagnation); resetting stagnation counter.");
+        stagnationCounter_ = 0;
+    }
+    previousPlan_ = lastPlan_;
+
     appendMemory("Cycle " + std::to_string(cognitiveCycle_) +
-                 " reasoning: goal = " + goalContext +
+                 " reasoning: focus_goal_id = " + (focus ? focus->id : std::string("none")) +
+                 "; goal = " + goalContext +
                  "; recent experience summary = " + summarizeRecentExperience() +
-                 "; selected plan = " + lastPlan_ + ".");
+                 "; competence = " + std::to_string(competenceSignal_) +
+                 "; selected plan = " + lastPlan_ +
+                 " (bias=" + std::to_string(bestBias) + ").");
     logInfo("Reasoning selected plan: " + lastPlan_);
     return input;
 }
@@ -610,10 +1216,132 @@ std::shared_ptr<void> AutonomousStarter::actionStep(std::shared_ptr<void> input)
     ++actionCounter_;
     const auto result = executeShellCommand(command);
 
+    // Capture the outcome so the reflection phase and the next reasoning cycle
+    // can adapt. This closes the observe->reason->act->reflect feedback loop.
+    lastActionCommand_ = command;
+    lastActionSucceeded_ = result.success;
+    lastActionOutput_ = result.output;
+    lastActionExitCode_ = result.exitCode;
+
     appendMemory("Cycle " + std::to_string(cognitiveCycle_) +
                  " action: command='" + command + "', success=" +
                  std::string(result.success ? "true" : "false") +
                  ", exitCode=" + std::to_string(result.exitCode) + ".");
+
+    // Close the loop: feed the action outcome back into goal state so successful,
+    // aligned actions complete the active goal and promote the next one. This is
+    // what turns the goal list from a static seed into a converging drive.
+    evaluateGoalProgress(lastPlan_, command, result);
+    return input;
+}
+
+std::string AutonomousStarter::activeGoalDescriptionForPlan() const {
+    // The currently-serving goal is the first non-terminal goal, matching the
+    // selection precedence used by selectGoalContext().
+    const auto& goals = state_.getGoals();
+    for (const auto& goal : goals) {
+        std::string status = toLowerAscii(goal.status);
+        if (status == "active" || status == "in_progress" || status == "pending") {
+            return goal.description;
+        }
+    }
+    return std::string();
+}
+
+std::shared_ptr<void> AutonomousStarter::reflectionStep(std::shared_ptr<void> input) {
+    // Reflection is the fourth Echobeats-aligned phase and the point where the
+    // observe->reason->act->reflect loop becomes self-regulating. It performs
+    // three complementary jobs:
+    //   1. Feed the action outcome back into per-plan success statistics and a
+    //      bounded competence signal that biases future plan selection.
+    //   2. Advance the focused goal's lifecycle (complete/rotate/escalate) so
+    //      the agent does not loop forever on a satisfied or failing probe.
+    //   3. Record an adaptive reflective note that becomes part of the
+    //      experience the next reasoning cycle summarizes.
+    recordPlanOutcome(lastPlan_, lastActionSucceeded_);
+    advanceGoalLifecycle(lastPlan_, lastActionSucceeded_);
+
+    // --- 1. Competence signal + rolling outcome window ---------------------
+    constexpr std::size_t kOutcomeWindow = 5;
+    recentActionOutcomes_.push_back(lastActionSucceeded_);
+    while (recentActionOutcomes_.size() > kOutcomeWindow) {
+        recentActionOutcomes_.pop_front();
+    }
+    if (lastActionSucceeded_) {
+        ++successfulActionCount_;
+        // Competence rises toward 1.0 with diminishing returns.
+        competenceSignal_ += (1.0 - competenceSignal_) * 0.2;
+    } else {
+        ++failedActionCount_;
+        // Competence falls toward 0.0 more sharply so failures register quickly.
+        competenceSignal_ -= competenceSignal_ * 0.3;
+    }
+    competenceSignal_ = std::max(0.0, std::min(1.0, competenceSignal_));
+
+    std::size_t windowFailures = 0;
+    for (bool ok : recentActionOutcomes_) {
+        if (!ok) ++windowFailures;
+    }
+
+    const double ratio = getPlanSuccessRatio(lastPlan_);
+    std::ostringstream reflection;
+    reflection << "Cycle " << cognitiveCycle_ << " reflection: plan='" << lastPlan_ << "'"
+               << ", action='" << lastActionCommand_ << "'"
+               << ", outcome=" << (lastActionSucceeded_ ? "succeeded" : "failed")
+               << ", exitCode=" << lastActionExitCode_
+               << ", competence=" << competenceSignal_
+               << ", plan_success_ratio=" << ratio
+               << ", recentFailures=" << windowFailures << "/" << recentActionOutcomes_.size()
+               << ", focus_goal=" << (focusedGoalId_.empty() ? "none" : focusedGoalId_) << "; ";
+
+    // --- 2. Goal lifecycle advancement / adaptive escalation ----------------
+    const std::string activeGoal = activeGoalDescriptionForPlan();
+    if (lastActionSucceeded_) {
+        consecutiveActionFailures_ = 0;
+
+        // Goal completion is owned by a SINGLE authoritative, evidence-gated path
+        // (evaluateGoalProgress in actionStep + advanceGoalLifecycle above). The
+        // reflection phase deliberately no longer completes goals by description
+        // nor force-activates the next pending goal: doing so previously raced the
+        // id-based path, double-completed on the first aligned success, and caused
+        // a sustained dominant goal to lose plan continuity after cycle 1. Here we
+        // only report the current convergence state; promotion of the next pending
+        // goal is handled deterministically by selectActiveGoal() on the next
+        // perception step, keeping exactly one goal in flight without a duplicate
+        // rotation mechanism.
+        completedGoalCount_ = getCompletedGoalCount();
+        reflection << "completed_total=" << completedGoalCount_;
+    } else {
+        ++consecutiveActionFailures_;
+        reflection << "consecutive_failures=" << consecutiveActionFailures_;
+
+        // Adaptive escalation: if the agent repeatedly fails, fall back to a
+        // minimal, guaranteed-safe situational-awareness goal so the next plan
+        // selects a low-risk probe rather than retrying a failing path.
+        if (consecutiveActionFailures_ >= 2 && !activeGoal.empty()) {
+            const Timestamp now = std::chrono::system_clock::now();
+            state_.updateGoalStatusByDescription(activeGoal, "blocked");
+            state_.addGoal(StateGoal{
+                generateUUID(),
+                "Re-establish bounded situational awareness after repeated action failure",
+                "active",
+                now,
+                now
+            });
+            reflection << "; escalated: blocked failing goal and re-seeded safe awareness goal";
+        } else if (competenceSignal_ > 0.8) {
+            reflection << "; lesson=high competence, free to pursue more novel goals";
+        } else {
+            reflection << "; lesson=steady progress, continuing current strategy";
+        }
+    }
+
+    lastReflection_ = reflection.str();
+    ++reflectionCount_;
+    appendMemory(lastReflection_);
+    logInfo("Reflection: competence=" + std::to_string(competenceSignal_) +
+            " outcome=" + std::string(lastActionSucceeded_ ? "succeeded" : "failed"));
+    logInfo(lastReflection_);
     return input;
 }
 

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -609,3 +609,26 @@ add_real_test(real_autonomy_optimizer_test src/test_autonomy_optimizer.cpp)
 if(TARGET real_autonomy_optimizer_test)
     list(APPEND ELIZAOS_KSM_CANONICAL_TEST_TARGETS real_autonomy_optimizer_test)
 endif()
+
+# ============================================================================
+# Closed-loop autonomy suite - ported from hurdcog for cross-fork parity.
+# Validates the advanced attention-weighted, evidence-gated goal lifecycle
+# (single completion path, active-goal invariant, purposeful-repetition
+# stagnation exemption) now shared by both forks.
+# ============================================================================
+add_real_test(real_closed_loop_autonomy_test src/test_closed_loop_autonomy.cpp)
+if(TARGET real_closed_loop_autonomy_test)
+    list(APPEND ELIZAOS_KSM_CANONICAL_TEST_TARGETS real_closed_loop_autonomy_test)
+endif()
+add_real_test(real_autonomy_reflection_test src/test_autonomy_reflection.cpp)
+if(TARGET real_autonomy_reflection_test)
+    list(APPEND ELIZAOS_KSM_CANONICAL_TEST_TARGETS real_autonomy_reflection_test)
+endif()
+add_real_test(real_autonomy_evolution_test src/test_autonomy_evolution.cpp)
+if(TARGET real_autonomy_evolution_test)
+    list(APPEND ELIZAOS_KSM_CANONICAL_TEST_TARGETS real_autonomy_evolution_test)
+endif()
+add_real_test(real_attention_bus_test src/test_attention_bus.cpp)
+if(TARGET real_attention_bus_test)
+    list(APPEND ELIZAOS_KSM_CANONICAL_TEST_TARGETS real_attention_bus_test)
+endif()

--- a/cpp/tests/src/test_attention_bus.cpp
+++ b/cpp/tests/src/test_attention_bus.cpp
@@ -1,0 +1,276 @@
+// test_attention_bus.cpp
+//
+// Comprehensive end-to-end tests for the inter-agent attention coordination
+// center: AttentionMessageBus + AttentionTransferProtocol bus integration.
+//
+// These tests exercise real cross-agent-boundary behavior (no mocks): focus
+// broadcast fan-out, out-of-band listeners, routed transfer accept/reject,
+// unknown-target handling, shared swarm pools, and automatic unregistration
+// on protocol destruction.
+
+#include <gtest/gtest.h>
+
+#include "elizaos/attention.hpp"
+#include "elizaos/core.hpp"
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace elizaos;
+
+namespace {
+
+using Request = AttentionTransferProtocol::AttentionTransferRequest;
+using Response = AttentionTransferProtocol::AttentionTransferResponse;
+
+// ---------------------------------------------------------------------------
+// Registration semantics
+// ---------------------------------------------------------------------------
+
+TEST(AttentionMessageBus, RegistrationIsIdempotentAndCounted) {
+    AttentionMessageBus bus;
+    EXPECT_EQ(bus.agentCount(), 0u);
+
+    AttentionTransferProtocol a("agent-a");
+    AttentionTransferProtocol b("agent-b");
+
+    a.connectToBus(&bus);
+    b.connectToBus(&bus);
+    EXPECT_EQ(bus.agentCount(), 2u);
+    EXPECT_TRUE(bus.isRegistered("agent-a"));
+    EXPECT_TRUE(bus.isRegistered("agent-b"));
+    EXPECT_TRUE(a.isConnectedToBus());
+
+    // Re-connecting the same agent must not create a duplicate endpoint.
+    a.connectToBus(&bus);
+    EXPECT_EQ(bus.agentCount(), 2u);
+
+    a.disconnectFromBus();
+    EXPECT_EQ(bus.agentCount(), 1u);
+    EXPECT_FALSE(bus.isRegistered("agent-a"));
+    EXPECT_FALSE(a.isConnectedToBus());
+}
+
+TEST(AttentionMessageBus, ProtocolDestructionUnregistersFromBus) {
+    AttentionMessageBus bus;
+    AttentionTransferProtocol keeper("keeper");
+    keeper.connectToBus(&bus);
+
+    {
+        AttentionTransferProtocol transient("transient");
+        transient.connectToBus(&bus);
+        EXPECT_EQ(bus.agentCount(), 2u);
+    }  // transient destroyed here
+
+    EXPECT_EQ(bus.agentCount(), 1u);
+    EXPECT_FALSE(bus.isRegistered("transient"));
+    EXPECT_TRUE(bus.isRegistered("keeper"));
+}
+
+// ---------------------------------------------------------------------------
+// Focus broadcast fan-out
+// ---------------------------------------------------------------------------
+
+TEST(AttentionMessageBus, BroadcastFocusReachesOtherAgentsNotSelf) {
+    AttentionMessageBus bus;
+    AttentionTransferProtocol a("a");
+    AttentionTransferProtocol b("b");
+    AttentionTransferProtocol c("c");
+    a.connectToBus(&bus);
+    b.connectToBus(&bus);
+    c.connectToBus(&bus);
+
+    std::vector<UUID> bReceived;
+    std::vector<UUID> cReceived;
+    int aLocalHandlerCalls = 0;
+    std::string aLocalSource;
+
+    a.setFocusBroadcastHandler([&](const std::string& src, const std::vector<UUID>&) {
+        // By design the broadcaster's own local handler fires exactly once with
+        // its own id (back-compat). It must NOT receive a *remote* fan-out copy.
+        ++aLocalHandlerCalls;
+        aLocalSource = src;
+    });
+    b.setFocusBroadcastHandler([&](const std::string& src, const std::vector<UUID>& items) {
+        EXPECT_EQ(src, "a");
+        bReceived = items;
+    });
+    c.setFocusBroadcastHandler([&](const std::string& src, const std::vector<UUID>& items) {
+        EXPECT_EQ(src, "a");
+        cReceived = items;
+    });
+
+    const std::vector<UUID> focus{"mem-1", "mem-2"};
+    const size_t reached = a.broadcastFocus(focus);
+
+    EXPECT_EQ(reached, 2u);            // remote fan-out to b and c only
+    EXPECT_EQ(bReceived, focus);
+    EXPECT_EQ(cReceived, focus);
+    EXPECT_EQ(aLocalHandlerCalls, 1);  // local handler fired once, not via remote fan-out
+    EXPECT_EQ(aLocalSource, "a");      // and it saw its own id as the source
+}
+
+TEST(AttentionMessageBus, BusLessBroadcastStillTriggersLocalHandler) {
+    AttentionTransferProtocol solo("solo");
+    bool localFired = false;
+    solo.setFocusBroadcastHandler([&](const std::string& src, const std::vector<UUID>&) {
+        EXPECT_EQ(src, "solo");
+        localFired = true;
+    });
+    const size_t reached = solo.broadcastFocus({"x"});
+    EXPECT_EQ(reached, 0u);   // no bus -> no remote endpoints
+    EXPECT_TRUE(localFired);  // local handler still invoked
+}
+
+TEST(AttentionMessageBus, OutOfBandListenerObservesEveryBroadcast) {
+    AttentionMessageBus bus;
+    AttentionTransferProtocol a("a");
+    AttentionTransferProtocol b("b");
+    a.connectToBus(&bus);
+    b.connectToBus(&bus);
+
+    std::atomic<int> observed{0};
+    std::string lastSource;
+    const size_t sub = bus.subscribe([&](const std::string& src, const std::vector<UUID>&) {
+        observed.fetch_add(1);
+        lastSource = src;
+    });
+
+    a.broadcastFocus({"i"});
+    b.broadcastFocus({"j"});
+    EXPECT_EQ(observed.load(), 2);
+    EXPECT_EQ(lastSource, "b");
+
+    bus.unsubscribe(sub);
+    a.broadcastFocus({"k"});
+    EXPECT_EQ(observed.load(), 2);  // listener removed, count unchanged
+}
+
+// ---------------------------------------------------------------------------
+// Routed transfer requests
+// ---------------------------------------------------------------------------
+
+TEST(AttentionMessageBus, TransferRoutedToTargetAgentHandler) {
+    AttentionMessageBus bus;
+    AttentionTransferProtocol sender("sender");
+    AttentionTransferProtocol receiver("receiver");
+    sender.connectToBus(&bus);
+    receiver.connectToBus(&bus);
+
+    // The receiver decides via its own installed handler.
+    bool receiverSaw = false;
+    receiver.setTransferHandler([&](const Request& req) {
+        receiverSaw = true;
+        EXPECT_EQ(req.sourceAgentId, "sender");
+        EXPECT_EQ(req.targetAgentId, "receiver");
+        Response r;
+        r.accepted = (req.attentionAmount <= 50.0);
+        r.actualAmount = r.accepted ? req.attentionAmount : 0.0;
+        r.message = r.accepted ? "ok" : "too much";
+        return r;
+    });
+
+    Request req;
+    req.sourceAgentId = "sender";
+    req.targetAgentId = "receiver";
+    req.memoryOrTaskId = "task-9";
+    req.attentionAmount = 25.0;
+    req.reason = "collaboration";
+
+    Response resp = sender.requestTransfer(req);
+    EXPECT_TRUE(receiverSaw);
+    EXPECT_TRUE(resp.accepted);
+    EXPECT_DOUBLE_EQ(resp.actualAmount, 25.0);
+    EXPECT_EQ(resp.message, "ok");
+
+    // Both endpoints should now track the transfer.
+    EXPECT_EQ(sender.getActiveTransfers().size(), 1u);
+    EXPECT_EQ(receiver.getActiveTransfers().size(), 1u);
+    EXPECT_TRUE(receiver.getActiveTransfers().front().isIncoming);
+    EXPECT_FALSE(sender.getActiveTransfers().front().isIncoming);
+}
+
+TEST(AttentionMessageBus, TransferToUnknownTargetIsRejectedNotCrashing) {
+    AttentionMessageBus bus;
+    AttentionTransferProtocol sender("sender");
+    sender.connectToBus(&bus);
+
+    Request req;
+    req.sourceAgentId = "sender";
+    req.targetAgentId = "ghost";  // never registered
+    req.attentionAmount = 5.0;
+
+    Response resp = sender.requestTransfer(req);
+    EXPECT_FALSE(resp.accepted);
+    EXPECT_NE(resp.message.find("not registered"), std::string::npos);
+    EXPECT_EQ(sender.getActiveTransfers().size(), 0u);
+}
+
+TEST(AttentionMessageBus, RoutedTransferRejectionPropagates) {
+    AttentionMessageBus bus;
+    AttentionTransferProtocol sender("sender");
+    AttentionTransferProtocol receiver("receiver");
+    sender.connectToBus(&bus);
+    receiver.connectToBus(&bus);
+
+    // Receiver uses the default policy (reject > 10.0).
+    Request req;
+    req.sourceAgentId = "sender";
+    req.targetAgentId = "receiver";
+    req.attentionAmount = 99.0;
+
+    Response resp = sender.requestTransfer(req);
+    EXPECT_FALSE(resp.accepted);
+    EXPECT_EQ(sender.getActiveTransfers().size(), 0u);
+    EXPECT_EQ(receiver.getActiveTransfers().size(), 0u);
+}
+
+TEST(AttentionMessageBus, BusLessTransferUsesLocalDefaultPolicy) {
+    AttentionTransferProtocol solo("solo");
+    Request small;
+    small.targetAgentId = "solo";  // self/no bus -> local policy
+    small.attentionAmount = 3.0;
+    EXPECT_TRUE(solo.requestTransfer(small).accepted);
+
+    Request big;
+    big.targetAgentId = "solo";
+    big.attentionAmount = 1000.0;
+    EXPECT_FALSE(solo.requestTransfer(big).accepted);
+}
+
+// ---------------------------------------------------------------------------
+// Shared swarm pools
+// ---------------------------------------------------------------------------
+
+TEST(AttentionMessageBus, SharedPoolContributeWithdrawBalance) {
+    AttentionMessageBus bus;
+    EXPECT_DOUBLE_EQ(bus.getSharedPoolBalance("swarm"), 0.0);
+
+    bus.contributeToSharedPool("swarm", 40.0);
+    bus.contributeToSharedPool("swarm", 10.0);
+    EXPECT_DOUBLE_EQ(bus.getSharedPoolBalance("swarm"), 50.0);
+
+    const double w = bus.withdrawFromSharedPool("swarm", 30.0);
+    EXPECT_DOUBLE_EQ(w, 30.0);
+    EXPECT_DOUBLE_EQ(bus.getSharedPoolBalance("swarm"), 20.0);
+
+    // Over-withdraw is clamped to the available balance and drains the pool.
+    const double w2 = bus.withdrawFromSharedPool("swarm", 1000.0);
+    EXPECT_DOUBLE_EQ(w2, 20.0);
+    EXPECT_DOUBLE_EQ(bus.getSharedPoolBalance("swarm"), 0.0);
+
+    // Withdrawing from an empty/unknown pool yields zero, never negative.
+    EXPECT_DOUBLE_EQ(bus.withdrawFromSharedPool("none", 5.0), 0.0);
+}
+
+TEST(AttentionMessageBus, ProcessWideInstanceIsUsable) {
+    auto& bus = AttentionMessageBus::instance();
+    const std::string poolId = "instance-pool-" + generateUUID();
+    bus.contributeToSharedPool(poolId, 7.0);
+    EXPECT_DOUBLE_EQ(bus.getSharedPoolBalance(poolId), 7.0);
+    EXPECT_DOUBLE_EQ(bus.withdrawFromSharedPool(poolId, 7.0), 7.0);
+}
+
+}  // namespace

--- a/cpp/tests/src/test_autonomy_evolution.cpp
+++ b/cpp/tests/src/test_autonomy_evolution.cpp
@@ -1,0 +1,324 @@
+// test_autonomy_evolution.cpp
+//
+// Comprehensive end-to-end coverage for the KSM autonomy-evolution upgrade to
+// the AutonomousStarter cognitive loop. These tests validate the newly added
+// self-regulating behaviors that turn the previous observe->reason->act stub
+// into a closed-loop perceive->reason->act->reflect autonomy engine:
+//
+//   1. Reflection phase actually runs and produces a non-empty conclusion every
+//      cognitive cycle (reflectionCount tracks cycle count).
+//   2. Attention-weighted goal selection focuses on an open goal and exposes a
+//      stable focused-goal id.
+//   3. Plan-success feedback accumulates real statistics that bias future plan
+//      selection (getPlanSuccessRatio is well-defined and bounded).
+//   4. Goal lifecycle transitions advance pending -> active -> completed when
+//      the agent reliably succeeds at its plans.
+//   5. The State::updateGoalStatus lifecycle-mutation API behaves correctly in
+//      isolation (found/updated vs. not-found, timestamp refresh).
+//   6. The full loop remains coherent and self-consistent across many cycles.
+//
+// Every assertion exercises real implementation behavior; there are no mocks.
+
+#include <gtest/gtest.h>
+
+#include "elizaos/goal_manager.hpp"  // MUST precede autonomous_starter.hpp
+#include "elizaos/autonomous_starter.hpp"
+#include "elizaos/core.hpp"
+
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace elizaos;
+using namespace std::chrono_literals;
+
+namespace {
+
+AgentConfig makeConfig(const std::string& name) {
+    AgentConfig cfg;
+    cfg.agentId = generateUUID();
+    cfg.agentName = name;
+    cfg.bio = "Autonomy-evolution E2E agent";
+    cfg.lore = "Created to validate the self-regulating cognitive loop";
+    cfg.adjective = "reflective";
+    return cfg;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// State::updateGoalStatus - lifecycle mutation API (structure-preserving)
+// ---------------------------------------------------------------------------
+
+class StateGoalLifecycleTest : public ::testing::Test {};
+
+TEST_F(StateGoalLifecycleTest, UpdatesStatusOfExistingGoal) {
+    State state(makeConfig("State-Goal"));
+    const Timestamp now = std::chrono::system_clock::now();
+    StateGoal goal{generateUUID(), "investigate workspace", "pending", now, now};
+    state.addGoal(goal);
+
+    ASSERT_EQ(state.getGoals().size(), 1u);
+    EXPECT_EQ(state.getGoals()[0].status, "pending");
+
+    const bool updated = state.updateGoalStatus(goal.id, "active");
+    EXPECT_TRUE(updated);
+    EXPECT_EQ(state.getGoals()[0].status, "active");
+}
+
+TEST_F(StateGoalLifecycleTest, ReturnsFalseForUnknownGoal) {
+    State state(makeConfig("State-Goal-Missing"));
+    const Timestamp now = std::chrono::system_clock::now();
+    state.addGoal(StateGoal{generateUUID(), "g", "pending", now, now});
+
+    EXPECT_FALSE(state.updateGoalStatus("nonexistent-id", "completed"));
+    // Existing goal must remain untouched.
+    EXPECT_EQ(state.getGoals()[0].status, "pending");
+}
+
+TEST_F(StateGoalLifecycleTest, RefreshesUpdatedTimestamp) {
+    State state(makeConfig("State-Goal-Timestamp"));
+    const Timestamp past =
+        std::chrono::system_clock::now() - std::chrono::hours(1);
+    StateGoal goal{generateUUID(), "g", "active", past, past};
+    state.addGoal(goal);
+
+    EXPECT_TRUE(state.updateGoalStatus(goal.id, "completed"));
+    EXPECT_GT(state.getGoals()[0].updatedAt, past);
+    EXPECT_EQ(state.getGoals()[0].status, "completed");
+}
+
+// ---------------------------------------------------------------------------
+// Reflection phase
+// ---------------------------------------------------------------------------
+
+class ReflectionLoopTest : public ::testing::Test {};
+
+TEST_F(ReflectionLoopTest, ReflectionRunsEveryCycle) {
+    AutonomousStarter agent(makeConfig("Reflective-Agent"));
+    agent.start();
+
+    EXPECT_EQ(agent.getReflectionCount(), 0u);
+
+    for (std::size_t i = 1; i <= 4; ++i) {
+        agent.runCognitiveCycleOnce();
+        // One reflection per cognitive cycle.
+        EXPECT_EQ(agent.getReflectionCount(), i);
+        // Reflection conclusion must be populated and reference a plan.
+        EXPECT_FALSE(agent.getLastReflection().empty());
+        EXPECT_NE(agent.getLastReflection().find("reflection"), std::string::npos);
+    }
+
+    agent.stop();
+}
+
+TEST_F(ReflectionLoopTest, ReflectionRecordsActionOutcome) {
+    AutonomousStarter agent(makeConfig("Outcome-Agent"));
+    agent.start();
+    agent.runCognitiveCycleOnce();
+
+    // The reflection text must report either success or failure of the action,
+    // and the boolean accessor must agree with the recorded reflection.
+    const std::string reflection = agent.getLastReflection();
+    const bool succeeded = agent.getLastActionSucceeded();
+    if (succeeded) {
+        EXPECT_NE(reflection.find("succeeded"), std::string::npos);
+    } else {
+        EXPECT_NE(reflection.find("failed"), std::string::npos);
+    }
+
+    agent.stop();
+}
+
+// ---------------------------------------------------------------------------
+// Attention-weighted goal selection
+// ---------------------------------------------------------------------------
+
+class AttentionFocusTest : public ::testing::Test {};
+
+TEST_F(AttentionFocusTest, FocusesOnAnOpenGoal) {
+    AutonomousStarter agent(makeConfig("Focus-Agent"));
+    agent.start();
+
+    // Before reasoning there is no committed focus.
+    EXPECT_TRUE(agent.getFocusedGoalId().empty());
+
+    agent.runCognitiveCycleOnce();
+
+    // After a cycle the agent must have committed to a concrete goal id, and
+    // that id must correspond to one of the seeded goals.
+    const UUID focused = agent.getFocusedGoalId();
+    EXPECT_FALSE(focused.empty());
+
+    bool matchesSeededGoal = false;
+    for (const auto& goal : agent.getState().getGoals()) {
+        if (goal.id == focused) {
+            matchesSeededGoal = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(matchesSeededGoal);
+
+    agent.stop();
+}
+
+TEST_F(AttentionFocusTest, FocusRemainsValidAcrossCycles) {
+    AutonomousStarter agent(makeConfig("Focus-Stability"));
+    agent.start();
+
+    for (int i = 0; i < 6; ++i) {
+        agent.runCognitiveCycleOnce();
+        const UUID focused = agent.getFocusedGoalId();
+        EXPECT_FALSE(focused.empty());
+        bool valid = false;
+        for (const auto& goal : agent.getState().getGoals()) {
+            if (goal.id == focused) {
+                valid = true;
+                break;
+            }
+        }
+        EXPECT_TRUE(valid) << "focused goal id must always map to a real goal";
+    }
+
+    agent.stop();
+}
+
+// ---------------------------------------------------------------------------
+// Plan-success feedback learning
+// ---------------------------------------------------------------------------
+
+class PlanFeedbackTest : public ::testing::Test {};
+
+TEST_F(PlanFeedbackTest, PlanSuccessRatioIsBounded) {
+    AutonomousStarter agent(makeConfig("Feedback-Agent"));
+    agent.start();
+
+    // Run enough cycles to accumulate plan statistics.
+    for (int i = 0; i < 8; ++i) {
+        agent.runCognitiveCycleOnce();
+    }
+
+    // The plan the agent most recently committed to must have a well-defined,
+    // bounded success ratio in [0,1].
+    const std::string plan = agent.getLastPlan();
+    EXPECT_FALSE(plan.empty());
+    const double ratio = agent.getPlanSuccessRatio(plan);
+    EXPECT_GE(ratio, 0.0);
+    EXPECT_LE(ratio, 1.0);
+
+    // Unknown plans must report 0.0 rather than crash.
+    EXPECT_DOUBLE_EQ(agent.getPlanSuccessRatio("a plan never executed"), 0.0);
+
+    agent.stop();
+}
+
+TEST_F(PlanFeedbackTest, SuccessfulPlansAccumulatePositiveRatio) {
+    AutonomousStarter agent(makeConfig("Feedback-Positive"));
+    agent.start();
+
+    // Safe filesystem-introspection plans should generally succeed in the
+    // sandbox, so after several cycles at least one executed plan must have a
+    // strictly positive success ratio (proving feedback is actually recorded).
+    std::vector<std::string> seenPlans;
+    for (int i = 0; i < 10; ++i) {
+        agent.runCognitiveCycleOnce();
+        seenPlans.push_back(agent.getLastPlan());
+    }
+
+    bool anyPositive = false;
+    for (const auto& plan : seenPlans) {
+        if (agent.getPlanSuccessRatio(plan) > 0.0) {
+            anyPositive = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(anyPositive)
+        << "feedback learning must record at least one successful plan outcome";
+
+    agent.stop();
+}
+
+// ---------------------------------------------------------------------------
+// Goal lifecycle progression driven by autonomy
+// ---------------------------------------------------------------------------
+
+class GoalLifecycleProgressionTest : public ::testing::Test {};
+
+TEST_F(GoalLifecycleProgressionTest, GoalsProgressTowardCompletion) {
+    AutonomousStarter agent(makeConfig("Lifecycle-Agent"));
+    agent.start();
+
+    auto countByStatus = [&](const std::string& status) {
+        std::size_t n = 0;
+        for (const auto& goal : agent.getState().getGoals()) {
+            std::string s = goal.status;
+            for (auto& c : s) c = static_cast<char>(::tolower(c));
+            if (s == status) ++n;
+        }
+        return n;
+    };
+
+    const std::size_t initialPending = countByStatus("pending");
+    EXPECT_GE(agent.getState().getGoals().size(), 1u);
+
+    // Drive many cycles so the agent can transition goals through their
+    // lifecycle as plans prove reliable.
+    for (int i = 0; i < 20; ++i) {
+        agent.runCognitiveCycleOnce();
+    }
+
+    // The autonomy loop must make measurable progress: either some pending goal
+    // became active/completed, or a goal reached the completed state.
+    const std::size_t finalPending = countByStatus("pending");
+    const std::size_t finalCompleted = countByStatus("completed");
+    const std::size_t finalActive = countByStatus("active");
+
+    EXPECT_TRUE(finalPending < initialPending || finalCompleted > 0 ||
+                finalActive > 0)
+        << "goal lifecycle must advance under sustained autonomy";
+
+    agent.stop();
+}
+
+// ---------------------------------------------------------------------------
+// Full-loop coherence
+// ---------------------------------------------------------------------------
+
+class FullLoopCoherenceTest : public ::testing::Test {};
+
+TEST_F(FullLoopCoherenceTest, AllFourPhasesStayConsistent) {
+    AutonomousStarter agent(makeConfig("Coherence-E2E"));
+    agent.start();
+
+    const int kCycles = 12;
+    for (int i = 0; i < kCycles; ++i) {
+        agent.runCognitiveCycleOnce();
+
+        // Each cycle must leave the agent in a fully consistent state.
+        EXPECT_FALSE(agent.getLastObservationSummary().empty());
+        EXPECT_FALSE(agent.getLastPlan().empty());
+        EXPECT_FALSE(agent.getLastReflection().empty());
+    }
+
+    // Cycle, action, and reflection counters must all advance in lock-step:
+    // exactly one perception, one action, and one reflection per cycle.
+    EXPECT_EQ(agent.getCognitiveCycleCount(),
+              static_cast<std::size_t>(kCycles));
+    EXPECT_EQ(agent.getActionCount(), static_cast<std::size_t>(kCycles));
+    EXPECT_EQ(agent.getReflectionCount(), static_cast<std::size_t>(kCycles));
+
+    // Memory must accumulate strictly. Reasoning, action, and reflection each
+    // append at least one named cycle memory, so the recent-message stream must
+    // grow by at least two entries per cycle (a conservative lower bound that
+    // holds even if individual shell observations are coalesced).
+    EXPECT_GE(agent.getState().getRecentMessages().size(),
+              static_cast<std::size_t>(kCycles) * 2);
+
+    agent.stop();
+}
+
+TEST_F(FullLoopCoherenceTest, SelfCheckStillPassesAfterEvolution) {
+    // The optimized loop must not regress the package self-check.
+    EXPECT_TRUE(autonomous_starter_self_check());
+}

--- a/cpp/tests/src/test_autonomy_reflection.cpp
+++ b/cpp/tests/src/test_autonomy_reflection.cpp
@@ -1,0 +1,391 @@
+// test_autonomy_reflection.cpp
+// Comprehensive E2E coverage for the closed-loop autonomy enhancements added to
+// AutonomousStarter: the four-phase observe->reason->act->reflect cognitive
+// cycle, the bounded competence signal, failure-driven plan fallback, and
+// attention-weighted goal prioritization.
+//
+// These tests exercise the public AutonomousStarter API only, so they lock in
+// the behavioral contract of the self-regulating loop without depending on
+// private implementation details.
+
+#include <gtest/gtest.h>
+#include "elizaos/autonomous_starter.hpp"
+#include "elizaos/core.hpp"
+
+#include <string>
+#include <vector>
+//
+// E2E tests for the closed-loop reflection phase of the autonomy cognitive
+// cycle. Prior to the reflection repair, AutonomousStarter ran a strictly
+// open-loop observe -> reason -> act cycle: action outcomes were written to
+// memory but never fed back into goal state, so goals were never progressed or
+// completed and planning could not adapt to repeated failures.
+//
+// These tests assert the self-regulating behavior added by reflectionStep():
+//   * action outcomes are captured (success flag + exit code),
+//   * a satisfied active goal is marked completed and counted,
+//   * the agent rotates to the next pending goal instead of looping,
+//   * the new State goal-status mutation API behaves as documented,
+//   * repeated failures escalate to a safe re-seeded awareness goal.
+//
+// They also exercise the State::updateGoalStatus / updateGoalStatusByDescription
+// / countGoalsWithStatus surface directly so the additive core API is covered.
+
+#include <gtest/gtest.h>
+#include "elizaos/core.hpp"
+#include "elizaos/autonomous_starter.hpp"
+
+#include <string>
+
+using namespace elizaos;
+
+namespace {
+
+AgentConfig makeConfig(const std::string& name = "Reflection-Agent") {
+    AgentConfig cfg;
+    cfg.agentId = generateUUID();
+    cfg.agentName = name;
+    cfg.bio = "Reflection/feedback autonomy test agent";
+    cfg.lore = "Created to validate the closed-loop cognitive cycle";
+    cfg.adjective = "introspective";
+    return cfg;
+}
+
+// Count how many recent-memory entries contain a given substring.
+std::size_t countMemoriesContaining(const State& state, const std::string& needle) {
+    std::size_t count = 0;
+    for (const auto& mem : state.getRecentMessages()) {
+        if (mem && mem->getContent().find(needle) != std::string::npos) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+} // namespace
+
+// The cycle must run all four phases, each leaving a distinct memory trace.
+TEST(AutonomyReflectionTest, FourPhaseCycleLeavesPerceptionReasoningActionReflectionMemories) {
+    AutonomousStarter agent(makeConfig("FourPhase-Agent"));
+    agent.start();
+
+    agent.runCognitiveCycleOnce();
+
+    const State& state = agent.getState();
+    EXPECT_GE(countMemoriesContaining(state, "perception:"), 1u);
+    EXPECT_GE(countMemoriesContaining(state, "reasoning:"), 1u);
+    EXPECT_GE(countMemoriesContaining(state, "action:"), 1u);
+    EXPECT_GE(countMemoriesContaining(state, "reflection:"), 1u);
+
+    agent.stop();
+}
+
+// Reflection state must be populated after a cycle and reference the cycle.
+TEST(AutonomyReflectionTest, ReflectionSummaryIsPopulatedAndCoherent) {
+    AutonomousStarter agent(makeConfig("ReflectionSummary-Agent"));
+    agent.start();
+
+    EXPECT_TRUE(agent.getLastReflection().empty());
+    agent.runCognitiveCycleOnce();
+
+    const std::string reflection = agent.getLastReflection();
+    EXPECT_FALSE(reflection.empty());
+    EXPECT_NE(reflection.find("reflection:"), std::string::npos);
+    EXPECT_NE(reflection.find("competence="), std::string::npos);
+    EXPECT_NE(reflection.find("outcome="), std::string::npos);
+
+    agent.stop();
+}
+
+// Competence must stay bounded in [0, 1] and rise with successful actions.
+TEST(AutonomyReflectionTest, CompetenceSignalStaysBoundedAndRisesOnSuccess) {
+    AutonomousStarter agent(makeConfig("Competence-Agent"));
+    agent.start();
+
+    const double initial = agent.getCompetenceSignal();
+    EXPECT_GE(initial, 0.0);
+    EXPECT_LE(initial, 1.0);
+
+    // Safe default plans produce successful shell commands, so competence should
+    // be non-decreasing across several cycles and remain bounded.
+    double previous = initial;
+    for (int i = 0; i < 6; ++i) {
+        agent.runCognitiveCycleOnce();
+        const double current = agent.getCompetenceSignal();
+        EXPECT_GE(current, 0.0);
+        EXPECT_LE(current, 1.0);
+        EXPECT_GE(current + 1e-9, previous); // monotone non-decreasing on success
+        previous = current;
+    }
+
+    // After repeated successful actions competence should have grown.
+    EXPECT_GT(agent.getCompetenceSignal(), initial);
+    EXPECT_GE(agent.getSuccessfulActionCount(), 1u);
+
+    agent.stop();
+}
+
+// Successful-action accounting must match the number of cycles when all succeed.
+TEST(AutonomyReflectionTest, SuccessfulActionCountTracksCycles) {
+    AutonomousStarter agent(makeConfig("ActionCount-Agent"));
+    agent.start();
+
+    constexpr int kCycles = 4;
+    for (int i = 0; i < kCycles; ++i) {
+        agent.runCognitiveCycleOnce();
+    }
+
+    EXPECT_TRUE(agent.lastActionSucceeded());
+    EXPECT_EQ(agent.getSuccessfulActionCount() + agent.getFailedActionCount(),
+              static_cast<std::size_t>(kCycles));
+    // Default safe commands succeed, so there should be no failures.
+    EXPECT_EQ(agent.getFailedActionCount(), 0u);
+
+    agent.stop();
+}
+
+// Attention-prioritized goal selection must return one of the seeded goals.
+TEST(AutonomyReflectionTest, AttentionPrioritizedGoalMatchesASeededGoal) {
+    AutonomousStarter agent(makeConfig("AttentionGoal-Agent"));
+    agent.start();
+
+    const auto& goals = agent.getState().getGoals();
+    ASSERT_GE(goals.size(), 1u);
+
+    const std::string prioritized = agent.getAttentionPrioritizedGoal();
+    EXPECT_FALSE(prioritized.empty());
+
+    bool matchesAGoal = false;
+    for (const auto& goal : goals) {
+        if (goal.description == prioritized) {
+            matchesAGoal = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(matchesAGoal);
+
+    agent.stop();
+}
+
+// Attention prioritization must be deterministic for an unchanged goal set.
+TEST(AutonomyReflectionTest, AttentionPrioritizationIsStableAcrossRepeatedCalls) {
+    AutonomousStarter agent(makeConfig("AttentionStable-Agent"));
+    agent.start();
+
+    const std::string first = agent.getAttentionPrioritizedGoal();
+    const std::string second = agent.getAttentionPrioritizedGoal();
+    EXPECT_EQ(first, second);
+
+    agent.stop();
+}
+
+// The reflection phase must keep producing fresh reflections each cycle.
+TEST(AutonomyReflectionTest, EachCycleProducesAFreshReflectionTrace) {
+    AutonomousStarter agent(makeConfig("FreshReflection-Agent"));
+    agent.start();
+
+    std::vector<std::string> reflections;
+    for (int i = 0; i < 3; ++i) {
+        agent.runCognitiveCycleOnce();
+        reflections.push_back(agent.getLastReflection());
+    }
+
+    // Each reflection should reference its own cycle number, so they differ.
+    for (std::size_t i = 0; i < reflections.size(); ++i) {
+        EXPECT_FALSE(reflections[i].empty());
+        const std::string marker = "Cycle " + std::to_string(i + 1) + " reflection:";
+        EXPECT_NE(reflections[i].find(marker), std::string::npos)
+            << "reflection " << i << " = " << reflections[i];
+    }
+
+    agent.stop();
+}
+
+// Reflection memories must accumulate one per cycle alongside the other phases.
+TEST(AutonomyReflectionTest, ReflectionMemoriesAccumulatePerCycle) {
+    AutonomousStarter agent(makeConfig("ReflectionAccrual-Agent"));
+    agent.start();
+
+    constexpr int kCycles = 3;
+    for (int i = 0; i < kCycles; ++i) {
+        agent.runCognitiveCycleOnce();
+    }
+
+    EXPECT_GE(countMemoriesContaining(agent.getState(), "reflection:"),
+              static_cast<std::size_t>(kCycles));
+
+    agent.stop();
+}
+
+// The cognitive cycle count must increase by exactly one per cycle even though
+// the cycle now performs four phases.
+TEST(AutonomyReflectionTest, CycleCountIncrementsOncePerFourPhaseCycle) {
+    AutonomousStarter agent(makeConfig("CycleCount-Agent"));
+    agent.start();
+
+    EXPECT_EQ(agent.getCognitiveCycleCount(), 0u);
+    agent.runCognitiveCycleOnce();
+    EXPECT_EQ(agent.getCognitiveCycleCount(), 1u);
+    agent.runCognitiveCycleOnce();
+    EXPECT_EQ(agent.getCognitiveCycleCount(), 2u);
+
+        agent.stop();
+}
+
+// ---------------------------------------------------------------------------
+// State goal-status mutation API (additive core surface)
+// ---------------------------------------------------------------------------
+
+TEST(StateGoalMutationTest, UpdateGoalStatusById) {
+    AgentConfig cfg = makeConfig("State-ById");
+    State state(cfg);
+
+    const Timestamp now = std::chrono::system_clock::now();
+    const UUID id = generateUUID();
+    state.addGoal(StateGoal{id, "Probe workspace", "active", now, now});
+
+    EXPECT_TRUE(state.updateGoalStatus(id, "completed"));
+    ASSERT_EQ(state.getGoals().size(), 1u);
+    EXPECT_EQ(state.getGoals()[0].status, "completed");
+
+    // Unknown id must not match.
+    EXPECT_FALSE(state.updateGoalStatus(generateUUID(), "active"));
+}
+
+TEST(StateGoalMutationTest, UpdateGoalStatusByDescriptionIsCaseInsensitive) {
+    AgentConfig cfg = makeConfig("State-ByDesc");
+    State state(cfg);
+
+    const Timestamp now = std::chrono::system_clock::now();
+    state.addGoal(StateGoal{generateUUID(), "Inspect Source", "pending", now, now});
+
+    // Match is case-insensitive on the description.
+    EXPECT_TRUE(state.updateGoalStatusByDescription("inspect source", "active"));
+    EXPECT_EQ(state.getGoals()[0].status, "active");
+
+    EXPECT_FALSE(state.updateGoalStatusByDescription("nonexistent goal", "active"));
+}
+
+TEST(StateGoalMutationTest, CountGoalsWithStatus) {
+    AgentConfig cfg = makeConfig("State-Count");
+    State state(cfg);
+
+    const Timestamp now = std::chrono::system_clock::now();
+    state.addGoal(StateGoal{generateUUID(), "g1", "active", now, now});
+    state.addGoal(StateGoal{generateUUID(), "g2", "pending", now, now});
+    state.addGoal(StateGoal{generateUUID(), "g3", "Completed", now, now});
+    state.addGoal(StateGoal{generateUUID(), "g4", "completed", now, now});
+
+    EXPECT_EQ(state.countGoalsWithStatus("active"), 1u);
+    EXPECT_EQ(state.countGoalsWithStatus("pending"), 1u);
+    // Case-insensitive: "Completed" and "completed" both count.
+    EXPECT_EQ(state.countGoalsWithStatus("completed"), 2u);
+    EXPECT_EQ(state.countGoalsWithStatus("blocked"), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Closed-loop reflection behavior on the autonomy cycle
+// ---------------------------------------------------------------------------
+
+class AutonomyReflectionFixtureTest : public ::testing::Test {
+protected:
+    AutonomyReflectionFixtureTest() : agent(makeConfig()) {}
+    AutonomousStarter agent;
+};
+
+TEST_F(AutonomyReflectionFixtureTest, ActionOutcomeIsCaptured) {
+    // A successful, safe probe must register as a captured action outcome.
+    agent.enableShellAccess(true);
+    const std::size_t cycles = agent.runCognitiveCycleOnce();
+
+    EXPECT_GE(cycles, 1u);
+    EXPECT_GE(agent.getActionCount(), 1u);
+    // The default autonomy probes (pwd/ls/find) succeed in the test sandbox.
+    EXPECT_TRUE(agent.getLastActionSucceeded());
+    EXPECT_EQ(agent.getLastActionExitCode(), 0);
+    EXPECT_FALSE(agent.getLastReflection().empty());
+}
+
+TEST_F(AutonomyReflectionFixtureTest, SuccessfulCycleProgressesGoals) {
+    agent.enableShellAccess(true);
+
+    // Before any cycle, no goals have been completed.
+    EXPECT_EQ(agent.getCompletedGoalCount(), 0u);
+
+    // Closed-loop convergence is evidence-driven, not one-shot: a goal is only
+    // marked completed once its serving plan has produced reliable, repeated
+    // evidence (a single successful probe is not proof of achievement -- treating
+    // it as such was the focus-drift defect this suite now guards against). Run a
+    // bounded window sufficient for the seeded goals to accrue that evidence.
+    for (int i = 0; i < 6; ++i) {
+        agent.runCognitiveCycleOnce();
+    }
+
+    // Having gathered reliable evidence, the loop closes: at least one goal has
+    // advanced to completed and the completion counter reflects it.
+    EXPECT_GE(agent.getCompletedGoalCount(), 1u);
+    const auto& goals = agent.getState().getGoals();
+    EXPECT_GE(agent.getState().countGoalsWithStatus("completed"), 1u);
+    EXPECT_FALSE(goals.empty());
+}
+
+TEST_F(AutonomyReflectionFixtureTest, GoalsRotateAcrossCyclesInsteadOfLooping) {
+    agent.enableShellAccess(true);
+
+    // Run several cycles; the agent should progressively complete its seeded
+    // autonomy goals rather than re-running one satisfied probe forever. Progress
+    // is monotonically non-decreasing (a completed goal never reverts) and the
+    // window is long enough for the evidence-gated loop to converge on at least
+    // one goal without prematurely completing on a single probe.
+    std::size_t lastCompleted = 0;
+    for (int i = 0; i < 8; ++i) {
+        agent.runCognitiveCycleOnce();
+        EXPECT_GE(agent.getCompletedGoalCount(), lastCompleted);
+        lastCompleted = agent.getCompletedGoalCount();
+    }
+
+    // Multiple cycles must have produced monotonically non-decreasing progress
+    // and at least one completed goal overall.
+    EXPECT_GE(agent.getCompletedGoalCount(), 1u);
+    // The consecutive-failure counter stays at zero while probes succeed.
+    EXPECT_EQ(agent.getConsecutiveActionFailures(), 0u);
+}
+
+TEST_F(AutonomyReflectionFixtureTest, RepeatedFailureEscalatesToSafeGoal) {
+    // Disabling shell access makes every action fail, which must drive the
+    // adaptive escalation path: consecutive failures accumulate and a safe
+    // re-seeded awareness goal is added after the second failure.
+    agent.enableShellAccess(false);
+
+    agent.runCognitiveCycleOnce();
+    EXPECT_FALSE(agent.getLastActionSucceeded());
+    EXPECT_GE(agent.getConsecutiveActionFailures(), 1u);
+
+    const std::size_t goalsAfterFirst = agent.getState().getGoals().size();
+
+    agent.runCognitiveCycleOnce();
+    EXPECT_GE(agent.getConsecutiveActionFailures(), 2u);
+
+    // After two consecutive failures the reflection step re-seeds a safe
+    // awareness goal, so the goal set grows and a "blocked" goal exists.
+    const auto& goals = agent.getState().getGoals();
+    EXPECT_GT(goals.size(), goalsAfterFirst);
+    EXPECT_GE(agent.getState().countGoalsWithStatus("blocked"), 1u);
+
+    // No goal should have been marked completed while every action failed.
+    EXPECT_EQ(agent.getCompletedGoalCount(), 0u);
+}
+
+TEST_F(AutonomyReflectionFixtureTest, RecoveryResetsFailureCounter) {
+    // Fail twice, then re-enable shell access; the next successful cycle must
+    // reset the consecutive-failure counter, demonstrating self-recovery.
+    agent.enableShellAccess(false);
+    agent.runCognitiveCycleOnce();
+    agent.runCognitiveCycleOnce();
+    EXPECT_GE(agent.getConsecutiveActionFailures(), 2u);
+
+    agent.enableShellAccess(true);
+    agent.runCognitiveCycleOnce();
+    EXPECT_TRUE(agent.getLastActionSucceeded());
+    EXPECT_EQ(agent.getConsecutiveActionFailures(), 0u);
+}

--- a/cpp/tests/src/test_closed_loop_autonomy.cpp
+++ b/cpp/tests/src/test_closed_loop_autonomy.cpp
@@ -1,0 +1,209 @@
+// test_closed_loop_autonomy.cpp
+//
+// Comprehensive end-to-end tests for the closed-loop goal-progression autonomy
+// added to AutonomousStarter and the supporting State::updateGoalStatus API.
+//
+// These tests prove that goals are no longer a static decorative seed: the agent
+// advances pending -> active -> completed based on real action evidence, never
+// dead-ends (adaptive goal re-seeding), and escapes plan stagnation. Every
+// assertion exercises the real compiled canonical API -- no mocks, no stubs.
+#include <gtest/gtest.h>
+
+#include "elizaos/core.hpp"
+#include "elizaos/autonomous_starter.hpp"
+
+#include <chrono>
+#include <string>
+
+using namespace elizaos;
+
+namespace {
+
+AgentConfig makeConfig(const std::string& name = "ClosedLoop-Agent") {
+    AgentConfig cfg;
+    cfg.agentId = generateUUID();
+    cfg.agentName = name;
+    cfg.bio = "Closed-loop goal-progression autonomy test agent";
+    cfg.lore = "Created to validate converging goal-driven autonomy";
+    cfg.adjective = "deliberate";
+    return cfg;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// State::updateGoalStatus -- the minimal canonical surface that makes the goal
+// center mutable and therefore alive.
+// ---------------------------------------------------------------------------
+
+TEST(StateGoalLifecycleTest, UpdateGoalStatusTransitionsExistingGoal) {
+    State state(makeConfig());
+    const Timestamp now = std::chrono::system_clock::now();
+    const UUID goalId = generateUUID();
+    state.addGoal(StateGoal{goalId, "Investigate workspace", "pending", now, now});
+
+    ASSERT_EQ(state.getGoals().size(), 1u);
+    EXPECT_EQ(state.getGoals().front().status, "pending");
+
+    const Timestamp before = state.getGoals().front().updatedAt;
+    const bool updated = state.updateGoalStatus(goalId, "active");
+
+    EXPECT_TRUE(updated);
+    EXPECT_EQ(state.getGoals().front().status, "active");
+    // updatedAt must advance (monotonic, never regress).
+    EXPECT_GE(state.getGoals().front().updatedAt, before);
+}
+
+TEST(StateGoalLifecycleTest, UpdateGoalStatusReturnsFalseForUnknownGoal) {
+    State state(makeConfig());
+    const Timestamp now = std::chrono::system_clock::now();
+    state.addGoal(StateGoal{generateUUID(), "Known goal", "pending", now, now});
+
+    EXPECT_FALSE(state.updateGoalStatus(generateUUID(), "completed"));
+    // The existing goal must be untouched.
+    EXPECT_EQ(state.getGoals().front().status, "pending");
+}
+
+TEST(StateGoalLifecycleTest, UpdateGoalStatusOnlyAffectsMatchingGoal) {
+    State state(makeConfig());
+    const Timestamp now = std::chrono::system_clock::now();
+    const UUID first = generateUUID();
+    const UUID second = generateUUID();
+    state.addGoal(StateGoal{first, "First", "pending", now, now});
+    state.addGoal(StateGoal{second, "Second", "pending", now, now});
+
+    EXPECT_TRUE(state.updateGoalStatus(second, "completed"));
+    EXPECT_EQ(state.getGoals()[0].status, "pending");
+    EXPECT_EQ(state.getGoals()[1].status, "completed");
+}
+
+// ---------------------------------------------------------------------------
+// AutonomousStarter closed-loop goal progression.
+// ---------------------------------------------------------------------------
+
+class ClosedLoopAutonomyTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        agent_ = std::make_shared<AutonomousStarter>(makeConfig());
+        agent_->start();
+    }
+
+    void TearDown() override {
+        if (agent_) {
+            agent_->stop();
+        }
+    }
+
+    std::shared_ptr<AutonomousStarter> agent_;
+};
+
+TEST_F(ClosedLoopAutonomyTest, StartSeedsCoreGoalsWithOpenWork) {
+    // start() must seed core autonomy goals so the agent has something to drive.
+    EXPECT_GE(agent_->getState().getGoals().size(), 1u);
+    EXPECT_GE(agent_->getOpenGoalCount(), 1u);
+    EXPECT_EQ(agent_->getCompletedGoalCount(), 0u);
+}
+
+TEST_F(ClosedLoopAutonomyTest, FirstCycleSelectsAndPursuesAnActiveGoal) {
+    agent_->runCognitiveCycleOnce();
+    // After a cycle the agent must have pursued a concrete goal: a plan was
+    // formed and at least one action executed. The active goal id may already be
+    // cleared if the goal completed within the cycle (the convergent fast path),
+    // so success is evidenced by progress, not by a still-pending pursuit.
+    EXPECT_FALSE(agent_->getLastPlan().empty());
+    EXPECT_GE(agent_->getActionCount(), 1u);
+    // Either a goal is still being pursued, or at least one goal has completed.
+    EXPECT_TRUE(!agent_->getActiveGoalId().empty() ||
+                agent_->getCompletedGoalCount() >= 1u);
+}
+
+TEST_F(ClosedLoopAutonomyTest, GoalsConvergeToCompletionOverMultipleCycles) {
+    const std::size_t initialOpen = agent_->getOpenGoalCount();
+    ASSERT_GE(initialOpen, 1u);
+
+    // Run enough bounded cycles to drive the seeded goals to completion.
+    for (int i = 0; i < 12; ++i) {
+        agent_->runCognitiveCycleOnce();
+    }
+
+    // The agent must have completed at least the originally seeded goals -- this
+    // is the core proof that goal state is closed-loop, not open-loop.
+    EXPECT_GE(agent_->getCompletedGoalCount(), initialOpen);
+    EXPECT_EQ(agent_->getCognitiveCycleCount(), 12u);
+}
+
+TEST_F(ClosedLoopAutonomyTest, AutonomyNeverDeadEndsOnOpenGoals) {
+    // After many cycles there must always remain at least one open goal to
+    // pursue (adaptive re-seeding), so the agent never idles with nothing to do.
+    for (int i = 0; i < 15; ++i) {
+        agent_->runCognitiveCycleOnce();
+    }
+    EXPECT_GE(agent_->getOpenGoalCount(), 1u);
+}
+
+TEST_F(ClosedLoopAutonomyTest, AdaptiveGoalsAreSeededAfterCompletion) {
+    const std::size_t seededAtStart = agent_->getState().getGoals().size();
+    for (int i = 0; i < 15; ++i) {
+        agent_->runCognitiveCycleOnce();
+    }
+    // Completing the seed goals should have grown the goal list with adaptive
+    // exploration goals.
+    EXPECT_GT(agent_->getState().getGoals().size(), seededAtStart);
+}
+
+TEST_F(ClosedLoopAutonomyTest, CompletedGoalsCarryEvidenceInMemory) {
+    for (int i = 0; i < 12; ++i) {
+        agent_->runCognitiveCycleOnce();
+    }
+    // The memory stream must record at least one explicit goal completion,
+    // proving the loop closed on observed evidence rather than a timer.
+    bool foundCompletion = false;
+    for (const auto& memory : agent_->getState().getRecentMessages()) {
+        if (memory && memory->getContent().find("Goal completed:") != std::string::npos) {
+            foundCompletion = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(foundCompletion);
+}
+
+TEST_F(ClosedLoopAutonomyTest, StagnationGuardKeepsStagnationBounded) {
+    // Across many cycles the stagnation counter must stay bounded (the guard
+    // resets it on escalation), proving the agent cannot lock into one plan.
+    for (int i = 0; i < 20; ++i) {
+        agent_->runCognitiveCycleOnce();
+        EXPECT_LE(agent_->getStagnationCounter(), 2u);
+    }
+}
+
+TEST_F(ClosedLoopAutonomyTest, ActiveGoalIsAlwaysAValidOpenGoalDuringPursuit) {
+    for (int i = 0; i < 8; ++i) {
+        agent_->runCognitiveCycleOnce();
+        const UUID active = agent_->getActiveGoalId();
+        if (active.empty()) {
+            continue;  // transient between completion and next promotion
+        }
+        bool matchesOpenGoal = false;
+        for (const auto& goal : agent_->getState().getGoals()) {
+            if (goal.id == active) {
+                EXPECT_NE(goal.status, "completed");
+                matchesOpenGoal = true;
+                break;
+            }
+        }
+        EXPECT_TRUE(matchesOpenGoal);
+    }
+}
+
+TEST_F(ClosedLoopAutonomyTest, ProgressIsDeterministicAcrossIdenticalRuns) {
+    // Two fresh agents driven the same number of cycles must reach the same
+    // completed-goal count -- progression is evidence-driven and deterministic.
+    auto secondAgent = std::make_shared<AutonomousStarter>(makeConfig("ClosedLoop-Agent-2"));
+    secondAgent->start();
+    for (int i = 0; i < 10; ++i) {
+        agent_->runCognitiveCycleOnce();
+        secondAgent->runCognitiveCycleOnce();
+    }
+    EXPECT_EQ(agent_->getCompletedGoalCount(), secondAgent->getCompletedGoalCount());
+    secondAgent->stop();
+}

--- a/include/elizaos/attention.hpp
+++ b/include/elizaos/attention.hpp
@@ -22,6 +22,12 @@ namespace elizaos {
  * importance, urgency, and novelty factors.
  */
 
+// ECAN Constants
+constexpr double MAX_STI = 1.0;  // Maximum short-term importance
+constexpr double MAX_LTI = 1.0;  // Maximum long-term importance
+constexpr double MIN_STI = 0.0;  // Minimum short-term importance
+constexpr double MIN_LTI = 0.0;  // Minimum long-term importance
+
 // Forward declarations
 struct AttentionValue;
 class AttentionBudget;
@@ -38,6 +44,12 @@ struct AttentionValue {
     double novelty = 0.0;       // Degree of novelty/surprise [0.0, 1.0]
     double activation = 0.0;    // Current activation level [0.0, 1.0]
     Timestamp lastUpdated = std::chrono::system_clock::now();
+    
+    // ECAN compatibility accessors (Short-term importance, Long-term importance)
+    double sti() const { return urgency; }      // Alias for short-term importance
+    double lti() const { return importance; }   // Alias for long-term importance
+    void setSTI(double val) { urgency = val; }
+    void setLTI(double val) { importance = val; }
     
     // Composite attention score calculation
     double getCompositeScore() const {
@@ -236,6 +248,479 @@ private:
     std::vector<std::string> extractFeatures(const std::string& content);
 };
 
+// ============================================================================
+// Phase 1.3: Multi-Scale Temporal Attention Window
+// ============================================================================
+
+/**
+ * Represents attention at different temporal scales
+ * Enables attention patterns that consider recent vs. distant history
+ */
+struct TemporalAttentionWindow {
+    double immediateAttention = 0.0;    // Last few seconds (working memory)
+    double shortTermAttention = 0.0;    // Last few minutes
+    double mediumTermAttention = 0.0;   // Last few hours
+    double longTermAttention = 0.0;     // Days to weeks
+    
+    Timestamp windowStart;
+    std::chrono::seconds immediateDuration{30};
+    std::chrono::minutes shortTermDuration{30};
+    std::chrono::hours mediumTermDuration{24};
+    std::chrono::hours longTermDuration{24 * 7};  // One week
+    
+    // Get weighted composite attention across scales
+    double getCompositeAttention(double immediateWeight = 0.4,
+                                 double shortTermWeight = 0.3,
+                                 double mediumTermWeight = 0.2,
+                                 double longTermWeight = 0.1) const {
+        return immediateAttention * immediateWeight +
+               shortTermAttention * shortTermWeight +
+               mediumTermAttention * mediumTermWeight +
+               longTermAttention * longTermWeight;
+    }
+    
+    // Update attention for a specific scale based on event time
+    void updateFromEvent(const Timestamp& eventTime, double attentionBoost = 0.1) {
+        auto now = std::chrono::system_clock::now();
+        auto age = now - eventTime;
+        
+        if (age < immediateDuration) {
+            immediateAttention = std::min(1.0, immediateAttention + attentionBoost);
+        } else if (age < std::chrono::duration_cast<std::chrono::seconds>(shortTermDuration)) {
+            shortTermAttention = std::min(1.0, shortTermAttention + attentionBoost);
+        } else if (age < std::chrono::duration_cast<std::chrono::seconds>(mediumTermDuration)) {
+            mediumTermAttention = std::min(1.0, mediumTermAttention + attentionBoost * 0.5);
+        } else if (age < std::chrono::duration_cast<std::chrono::seconds>(longTermDuration)) {
+            longTermAttention = std::min(1.0, longTermAttention + attentionBoost * 0.25);
+        }
+    }
+    
+    // Decay all temporal scales
+    void decay(double immDecay = 0.9, double shortDecay = 0.95, 
+               double medDecay = 0.98, double longDecay = 0.99) {
+        immediateAttention *= immDecay;
+        shortTermAttention *= shortDecay;
+        mediumTermAttention *= medDecay;
+        longTermAttention *= longDecay;
+    }
+};
+
+// ============================================================================
+// Phase 1.3: Saliency-Based Attention
+// ============================================================================
+
+/**
+ * Saliency detector for attention shifting
+ * Identifies what should capture attention based on novelty, relevance, and urgency
+ */
+class SaliencyDetector {
+public:
+    struct SaliencyFeatures {
+        double visualSaliency = 0.0;     // For visual inputs
+        double semanticSaliency = 0.0;   // Meaning-based importance
+        double temporalSaliency = 0.0;   // Recency/timing importance
+        double emotionalSaliency = 0.0;  // Emotional significance
+        double goalRelevance = 0.0;      // Relevance to current goals
+        
+        double getOverallSaliency() const {
+            return (visualSaliency + semanticSaliency + temporalSaliency + 
+                    emotionalSaliency + goalRelevance) / 5.0;
+        }
+    };
+    
+    SaliencyDetector() = default;
+    
+    // Calculate saliency for different input types
+    SaliencyFeatures calculateSaliency(const std::string& content,
+                                       const std::vector<std::string>& context = {},
+                                       const std::vector<std::string>& currentGoals = {});
+    
+    // Identify saliency-based attention shift targets
+    std::vector<UUID> identifyAttentionShiftTargets(
+        const std::unordered_map<UUID, AttentionValue>& currentAttention,
+        const std::vector<std::pair<UUID, SaliencyFeatures>>& candidates,
+        size_t maxShifts = 5);
+    
+    // Configure saliency weights
+    void setWeights(double visual, double semantic, double temporal, 
+                    double emotional, double goal);
+    
+private:
+    double visualWeight_ = 0.2;
+    double semanticWeight_ = 0.3;
+    double temporalWeight_ = 0.2;
+    double emotionalWeight_ = 0.15;
+    double goalWeight_ = 0.15;
+    
+    std::unordered_map<std::string, double> emotionalKeywords_;
+    void initializeEmotionalKeywords();
+};
+
+// ============================================================================
+// Phase 1.3: Attention Cost Budget
+// ============================================================================
+
+/**
+ * Manages attention allocation with strict resource limits
+ * Prevents attention exhaustion through cost tracking
+ */
+class AttentionCostBudget {
+public:
+    AttentionCostBudget(double totalBudget = 100.0, double regenerationRate = 1.0);
+    
+    struct AllocationRequest {
+        UUID targetId;
+        double requestedAmount;
+        double priority;            // Higher priority gets preference
+        bool canPartialAllocate;    // Accept less than requested?
+        std::chrono::milliseconds timeout{1000};  // How long to wait
+    };
+    
+    struct AllocationResult {
+        bool success;
+        double allocatedAmount;
+        double remainingBudget;
+        std::string reason;
+    };
+    
+    // Allocate attention with cost tracking
+    AllocationResult requestAllocation(const AllocationRequest& request);
+    
+    // Release attention back to pool
+    void releaseAttention(const UUID& targetId, double amount);
+    
+    // Budget management
+    double getAvailableBudget() const;
+    double getTotalBudget() const { return totalBudget_; }
+    void setTotalBudget(double budget);
+    void setRegenerationRate(double rate);
+    
+    // Regenerate budget over time
+    void tick(double deltaSeconds);
+    
+    // Get allocation history
+    struct AllocationHistory {
+        UUID targetId;
+        double amount;
+        Timestamp allocatedAt;
+        bool isActive;
+    };
+    std::vector<AllocationHistory> getAllocationHistory() const;
+    
+    // Emergency budget release (when exhausted)
+    void emergencyRelease(double threshold = 0.1);
+    
+private:
+    double totalBudget_;
+    std::atomic<double> availableBudget_;
+    double regenerationRate_;  // Units per second
+    
+    std::unordered_map<UUID, double> activeAllocations_;
+    std::vector<AllocationHistory> history_;
+    mutable std::mutex budgetMutex_;
+};
+
+// ============================================================================
+// Phase 1.3: Attention Pattern Learning
+// ============================================================================
+
+/**
+ * Learns and predicts attention patterns from history
+ * Enables proactive attention allocation
+ */
+class AttentionPatternLearner {
+public:
+    AttentionPatternLearner();
+    
+    struct AttentionEvent {
+        UUID targetId;
+        std::string category;       // "memory", "task", "input", etc.
+        double attentionLevel;
+        Timestamp timestamp;
+        std::unordered_map<std::string, std::string> context;
+    };
+    
+    struct LearnedPattern {
+        std::string patternType;    // "temporal", "contextual", "sequential"
+        std::vector<std::string> triggers;
+        std::vector<UUID> predictedTargets;
+        double confidence;
+        int occurrenceCount;
+    };
+    
+    // Record attention events for learning
+    void recordEvent(const AttentionEvent& event);
+    
+    // Learn patterns from recorded history
+    void learnPatterns();
+    
+    // Predict future attention needs
+    std::vector<std::pair<UUID, double>> predictAttentionNeeds(
+        const std::unordered_map<std::string, std::string>& currentContext,
+        size_t maxPredictions = 10);
+    
+    // Get learned patterns
+    std::vector<LearnedPattern> getPatterns() const;
+    
+    // Configuration
+    void setLearningRate(double rate) { learningRate_ = rate; }
+    void setMinPatternConfidence(double conf) { minPatternConfidence_ = conf; }
+    void setHistorySize(size_t size) { maxHistorySize_ = size; }
+    
+    // Prune low-confidence patterns
+    void prunePatterns(double minConfidence = 0.1);
+    
+private:
+    std::vector<AttentionEvent> eventHistory_;
+    std::vector<LearnedPattern> learnedPatterns_;
+    
+    double learningRate_ = 0.1;
+    double minPatternConfidence_ = 0.3;
+    size_t maxHistorySize_ = 10000;
+    
+    mutable std::mutex learnerMutex_;
+    
+    void detectTemporalPatterns();
+    void detectContextualPatterns();
+    void detectSequentialPatterns();
+};
+
+// ============================================================================
+// Phase 1.3: Inter-Agent Attention Transfer
+// ============================================================================
+
+class AttentionTransferProtocol;  // forward declaration
+
+/**
+ * In-process attention message bus.
+ *
+ * Provides a real cross-agent boundary so that multiple
+ * AttentionTransferProtocol instances running in the same process can
+ * exchange focus broadcasts, transfer requests and share collective
+ * attention pools without depending on a single locally-installed handler.
+ *
+ * The bus is thread-safe and may be used either as a process-wide default
+ * (AttentionMessageBus::instance()) or as an isolated instance for tests and
+ * sandboxed swarms.
+ */
+class AttentionMessageBus {
+public:
+    using FocusListener = std::function<void(const std::string& sourceAgentId,
+                                             const std::vector<UUID>& focusedItems)>;
+
+    AttentionMessageBus() = default;
+
+    // Process-wide default bus.
+    static AttentionMessageBus& instance();
+
+    // Register / unregister a protocol endpoint. Registration is idempotent.
+    void registerAgent(const std::string& agentId, AttentionTransferProtocol* protocol);
+    void unregisterAgent(const std::string& agentId);
+    bool isRegistered(const std::string& agentId) const;
+    size_t agentCount() const;
+
+    // Publish a focus broadcast from sourceAgentId to every OTHER registered
+    // endpoint. Returns the number of endpoints that received the broadcast.
+    size_t publishFocus(const std::string& sourceAgentId,
+                        const std::vector<UUID>& focusedItems);
+
+    // Subscribe an out-of-band listener (e.g. an avatar bridge or logger) that
+    // observes every focus broadcast on the bus. Returns a subscription id.
+    size_t subscribe(FocusListener listener);
+    void unsubscribe(size_t subscriptionId);
+
+    // Route a transfer request to the registered target agent. If the target is
+    // present its protocol handles the request; otherwise the request is
+    // rejected with a descriptive message.
+    struct RoutedTransferResult {
+        bool delivered;
+        bool accepted;
+        double actualAmount;
+        std::string message;
+    };
+    RoutedTransferResult routeTransfer(const struct AttentionTransferRequestEnvelope& envelope);
+
+    // Shared collective attention pools that live on the bus (swarm scenarios).
+    void contributeToSharedPool(const std::string& poolId, double amount);
+    double withdrawFromSharedPool(const std::string& poolId, double requestedAmount);
+    double getSharedPoolBalance(const std::string& poolId) const;
+
+private:
+    mutable std::mutex busMutex_;
+    std::unordered_map<std::string, AttentionTransferProtocol*> endpoints_;
+    std::unordered_map<size_t, FocusListener> listeners_;
+    std::unordered_map<std::string, double> sharedPools_;
+    size_t nextSubscriptionId_ = 1;
+};
+
+/**
+ * Enables attention coordination between agents
+ * Supports collaborative attention and attention sharing
+ */
+class AttentionTransferProtocol {
+public:
+    AttentionTransferProtocol(const std::string& agentId);
+    ~AttentionTransferProtocol();
+    
+    struct AttentionTransferRequest {
+        std::string sourceAgentId;
+        std::string targetAgentId;
+        UUID memoryOrTaskId;
+        double attentionAmount;
+        std::string reason;
+        std::chrono::seconds duration{60};  // How long transfer lasts
+    };
+    
+    struct AttentionTransferResponse {
+        bool accepted;
+        double actualAmount;
+        std::string message;
+    };
+    
+    // Initiate attention transfer to another agent
+    AttentionTransferResponse requestTransfer(const AttentionTransferRequest& request);
+    
+    // Handle incoming transfer requests
+    using TransferHandler = std::function<AttentionTransferResponse(const AttentionTransferRequest&)>;
+    void setTransferHandler(TransferHandler handler);
+    
+    // Broadcast attention focus to collaborating agents. When connected to a
+    // message bus the broadcast is delivered to every other agent on the bus;
+    // a locally-installed FocusBroadcastHandler is always invoked as well.
+    // Returns the number of remote endpoints reached (0 when bus-less).
+    size_t broadcastFocus(const std::vector<UUID>& focusedItems);
+    
+    // Receive focus broadcasts
+    using FocusBroadcastHandler = std::function<void(const std::string& agentId, 
+                                                      const std::vector<UUID>& focusedItems)>;
+    void setFocusBroadcastHandler(FocusBroadcastHandler handler);
+
+    // Connect this protocol to an attention message bus so that broadcasts and
+    // transfer requests cross the agent boundary. Passing nullptr (or calling
+    // disconnectFromBus) detaches and falls back to local-handler behavior.
+    void connectToBus(AttentionMessageBus* bus);
+    void disconnectFromBus();
+    bool isConnectedToBus() const;
+    const std::string& agentId() const { return agentId_; }
+
+    // Invoked by the bus when another agent broadcasts focus. Triggers the
+    // locally-installed FocusBroadcastHandler if present.
+    void deliverFocusBroadcast(const std::string& sourceAgentId,
+                               const std::vector<UUID>& focusedItems);
+
+    // Invoked by the bus to deliver a routed transfer request to this agent.
+    AttentionTransferResponse handleRoutedTransfer(const AttentionTransferRequest& request);
+    
+    // Collective attention pool for swarm scenarios
+    void contributeToPool(const std::string& poolId, double amount);
+    double withdrawFromPool(const std::string& poolId, double requestedAmount);
+    double getPoolBalance(const std::string& poolId) const;
+    
+    // Track active transfers
+    struct ActiveTransfer {
+        AttentionTransferRequest request;
+        Timestamp startTime;
+        Timestamp expiresAt;
+        bool isIncoming;
+    };
+    std::vector<ActiveTransfer> getActiveTransfers() const;
+    
+private:
+    std::string agentId_;
+    TransferHandler transferHandler_;
+    FocusBroadcastHandler focusBroadcastHandler_;
+    
+    std::unordered_map<std::string, double> attentionPools_;
+    std::vector<ActiveTransfer> activeTransfers_;
+    mutable std::mutex transferMutex_;
+    AttentionMessageBus* bus_ = nullptr;
+    
+    void cleanupExpiredTransfers();
+    // Records an accepted transfer in activeTransfers_. Caller must hold transferMutex_.
+    void trackTransferLocked(const AttentionTransferRequest& request);
+    // Decides whether a transfer is accepted using the installed handler or the
+    // default threshold policy. Caller must hold transferMutex_.
+    AttentionTransferResponse evaluateTransferLocked(const AttentionTransferRequest& request);
+};
+
+// Envelope used by AttentionMessageBus::routeTransfer to avoid a hard
+// dependency on the nested AttentionTransferProtocol::AttentionTransferRequest
+// type at the point of the bus declaration.
+struct AttentionTransferRequestEnvelope {
+    std::string sourceAgentId;
+    std::string targetAgentId;
+    UUID memoryOrTaskId;
+    double attentionAmount = 0.0;
+    std::string reason;
+    std::chrono::seconds duration{60};
+};
+
+// ============================================================================
+// Phase 1.3: Enhanced Attention Allocator
+// ============================================================================
+
+/**
+ * Enhanced attention allocator integrating all Phase 1.3 features
+ */
+class EnhancedAttentionAllocator : public AttentionAllocator {
+public:
+    EnhancedAttentionAllocator(const std::string& agentId = "default", 
+                               double initialBudget = 100.0);
+    ~EnhancedAttentionAllocator() = default;
+    
+    // Multi-scale temporal attention
+    void updateTemporalAttention(const UUID& elementId, const Timestamp& eventTime);
+    TemporalAttentionWindow getTemporalWindow(const UUID& elementId) const;
+    void decayAllTemporalWindows();
+    
+    // Saliency-based attention shifting
+    void enableSaliencyShifting(bool enable = true);
+    std::vector<UUID> computeSaliencyBasedShifts(
+        const std::vector<std::pair<UUID, std::string>>& candidates);
+    
+    // Cost-based budgeting
+    AttentionCostBudget::AllocationResult allocateWithCost(
+        const UUID& targetId, double amount, double priority = 1.0);
+    void tickBudget(double deltaSeconds);
+    
+    // Pattern learning
+    void enablePatternLearning(bool enable = true);
+    void recordAttentionEvent(const AttentionPatternLearner::AttentionEvent& event);
+    std::vector<std::pair<UUID, double>> getPredictedNeeds();
+    
+    // Inter-agent coordination
+    void enableInterAgentTransfer(bool enable = true);
+    AttentionTransferProtocol& getTransferProtocol();
+    
+    // Combined attention score considering all factors
+    double getEnhancedAttentionScore(const UUID& elementId) const;
+    
+    // Statistics
+    struct EnhancedStatistics {
+        AttentionStatistics base;
+        double averageTemporalScore;
+        double averageSaliencyScore;
+        double budgetUtilization;
+        int patternsPredicted;
+        int activeTransfers;
+    };
+    EnhancedStatistics getEnhancedStatistics() const;
+
+private:
+    std::string agentId_;
+    std::unordered_map<UUID, TemporalAttentionWindow> temporalWindows_;
+    std::unique_ptr<SaliencyDetector> saliencyDetector_;
+    std::unique_ptr<AttentionCostBudget> costBudget_;
+    std::unique_ptr<AttentionPatternLearner> patternLearner_;
+    std::unique_ptr<AttentionTransferProtocol> transferProtocol_;
+    
+    bool saliencyShiftingEnabled_ = false;
+    bool patternLearningEnabled_ = false;
+    bool interAgentTransferEnabled_ = false;
+    
+    mutable std::mutex enhancedMutex_;
+};
+
 /**
  * Attention-aware Memory Manager extension
  * Integrates attention allocation with memory management
@@ -271,8 +756,13 @@ public:
     // Attention allocator access
     std::shared_ptr<AttentionAllocator> getAttentionAllocator() const;
     
+    // Phase 1.3: Enhanced attention access
+    std::shared_ptr<EnhancedAttentionAllocator> getEnhancedAllocator() const;
+    void enableEnhancedAttention(const std::string& agentId = "default");
+    
 private:
     std::shared_ptr<AttentionAllocator> attentionAllocator_;
+    std::shared_ptr<EnhancedAttentionAllocator> enhancedAllocator_;
     std::shared_ptr<class AgentMemoryManager> memoryManager_;
     
     // Memory-attention mapping
@@ -308,6 +798,12 @@ namespace attention {
     // System maintenance
     void performMaintenance();
     void decayAttentionValues(double decayRate = 0.95);
+    
+    // Phase 1.3: Enhanced operations
+    void enableEnhanced(const std::string& agentId = "default");
+    double getEnhancedScore(const UUID& elementId);
+    std::vector<std::pair<UUID, double>> predictNeeds();
+    void recordEvent(const std::string& category, const UUID& targetId, double level);
 }
 
 } // namespace elizaos

--- a/include/elizaos/autonomous_starter.hpp
+++ b/include/elizaos/autonomous_starter.hpp
@@ -9,14 +9,18 @@
  * cognitive loop.
  */
 
-#include "core.hpp"
-#include "agentloop.hpp"
-#include "agentshell.hpp"
+#include "elizaos/core.hpp"
+#include "elizaos/agentloop.hpp"
+#include "elizaos/agentshell.hpp"
+#include "elizaos/attention.hpp"
 
 #include <atomic>
 #include <chrono>
+#include <deque>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace elizaos {
 
@@ -57,11 +61,53 @@ public:
 
     // Deterministic single-cycle autonomy controls for tests, supervisors, and
     // embedding runtimes that need bounded observe-reason-act stepping.
+    // Each cycle now runs the full perceive -> reason -> act -> reflect loop.
     std::size_t runCognitiveCycleOnce();
     std::size_t getCognitiveCycleCount() const { return cognitiveCycle_; }
     std::size_t getActionCount() const { return actionCounter_; }
     const std::string& getLastObservationSummary() const { return lastObservationSummary_; }
     const std::string& getLastPlan() const { return lastPlan_; }
+
+    // Closed-loop goal-progression introspection. These expose the convergence
+    // signals an autonomy supervisor needs: how many seeded goals are still open
+    // (pending/active/in_progress) versus completed, the id of the goal the agent
+    // is currently pursuing, and how many consecutive cycles produced the same
+    // plan (a stagnation signal). A healthy autonomous agent drives open goals to
+    // completion rather than looping a single plan indefinitely.
+    std::size_t getOpenGoalCount() const;
+    const UUID& getActiveGoalId() const { return activeGoalId_; }
+    std::size_t getStagnationCounter() const { return stagnationCounter_; }
+    // Reflection / learning surface. After each cycle the agent records whether
+    // the executed action succeeded and the reflective conclusion it drew.
+    const std::string& getLastReflection() const { return lastReflection_; }
+    std::size_t getReflectionCount() const { return reflectionCount_; }
+    bool getLastActionSucceeded() const { return lastActionSucceeded_; }
+    // Backwards-compatible alias retained for tests and embedders that adopted
+    // the shorter accessor name before the loop was unified.
+    bool lastActionSucceeded() const { return lastActionSucceeded_; }
+    int getLastActionExitCode() const { return lastActionExitCode_; }
+
+    // Attention-weighted autonomy introspection. Returns the goal id the agent
+    // is currently focused on (highest attention composite score among open
+    // goals), or an empty string when no goals exist.
+    UUID getFocusedGoalId() const { return focusedGoalId_; }
+
+    // Returns the success ratio (0.0-1.0) of every plan label the agent has
+    // executed so far. Used by supervisors and tests to confirm that the agent
+    // adapts plan selection based on accumulated outcome feedback.
+    double getPlanSuccessRatio(const std::string& plan) const;
+
+    // Bounded competence estimate in [0, 1]; rises after successful actions and
+    // falls after failures. Drives plan fallback selection on the next cycle.
+    double getCompetenceSignal() const { return competenceSignal_; }
+    std::size_t getSuccessfulActionCount() const { return successfulActionCount_; }
+    std::size_t getFailedActionCount() const { return failedActionCount_; }
+    std::size_t getCompletedGoalCount() const;
+    std::size_t getConsecutiveActionFailures() const { return consecutiveActionFailures_; }
+
+    // Attention-weighted goal selection. Exposes the goal the attention
+    // allocator currently considers highest priority. Empty when no goals.
+    std::string getAttentionPrioritizedGoal() const;
 
     // State access
     State& getState() { return state_; }
@@ -77,10 +123,58 @@ private:
     std::string selectGoalContext() const;
     std::string buildActionCommandForPlan(const std::string& plan) const;
 
+    // Closed-loop goal-progression helpers.
+    // selectActiveGoal picks the highest-priority open goal (active >
+    // in_progress > pending) and records its id in activeGoalId_.
+    // evaluateGoalProgress inspects the latest action evidence and advances goal
+    // statuses: a satisfied active goal becomes "completed", and the next pending
+    // goal is promoted to "active". seedAdaptiveGoal injects a fresh exploration
+    // goal when every seeded goal is complete so autonomy never dead-ends.
+    const StateGoal* selectActiveGoal();
+    void evaluateGoalProgress(const std::string& plan,
+                              const std::string& command,
+                              const ShellCommandResult& result);
+    void seedAdaptiveGoal();
+    bool planSatisfiesGoal(const StateGoal& goal,
+                           const std::string& plan,
+                           const ShellCommandResult& result) const;
+    // Topic-only variant of goal/plan alignment used by the stagnation guard to
+    // decide whether a repeated plan is purposeful (serving the current goal) or
+    // aimless. Unlike planSatisfiesGoal it takes an already-normalized goal string
+    // and does not require a successful ShellCommandResult, because it answers
+    // "does this plan serve this goal's topic?" independent of any single action's
+    // outcome.
+    bool planSatisfiesGoalTopic(const std::string& normalizedGoal,
+                                const std::string& plan) const;
+    // Attention-weighted goal selection. Seeds/refreshes attention values for
+    // every open goal and returns the highest-scoring open goal, falling back
+    // to the most recent goal when none are open.
+    const StateGoal* selectFocusGoal();
+    void refreshGoalAttention();
+
+    // Outcome-based plan adaptation. Records the success/failure of a plan and
+    // biases future plan selection toward historically successful plans.
+    void recordPlanOutcome(const std::string& plan, bool success);
+    double planBias(const std::string& plan) const;
+
+    // Goal lifecycle transition driven by accomplished plans.
+    void advanceGoalLifecycle(const std::string& plan, bool actionSucceeded);
+
     // Internal cognitive steps
+    // Internal cognitive steps. perception->reasoning->action->reflection forms
+    // the full four-phase Echobeats-aligned cognitive cycle.
     std::shared_ptr<void> perceptionStep(std::shared_ptr<void> input);
     std::shared_ptr<void> reasoningStep(std::shared_ptr<void> input);
     std::shared_ptr<void> actionStep(std::shared_ptr<void> input);
+    std::shared_ptr<void> reflectionStep(std::shared_ptr<void> input);
+
+    // Attention-driven goal prioritization helper. Scores currently open goals
+    // through the repository's AttentionAllocator and returns the description of
+    // the highest-scoring goal (falling back to selectGoalContext()).
+    std::string scoreAndSelectGoal() const;
+    // Map a satisfied plan probe back onto the goal it advances, returning the
+    // active goal description that the current plan is serving.
+    std::string activeGoalDescriptionForPlan() const;
 
     // Memory helpers
     void appendMemory(const std::string& content);
@@ -120,6 +214,38 @@ private:
     std::size_t actionCounter_{0};
     std::string lastObservationSummary_;
     std::string lastPlan_;
+
+    // Closed-loop goal-progression state.
+    UUID activeGoalId_;
+    std::string previousPlan_;
+    std::size_t stagnationCounter_{0};
+    std::size_t adaptiveGoalCounter_{0};
+    // Reflection / learning state.
+    std::string lastReflection_;
+    std::size_t reflectionCount_{0};
+    std::string lastActionOutput_;
+
+    // Closed-loop reflection / feedback state.
+    std::string lastActionCommand_;
+    bool lastActionSucceeded_{false};
+    int lastActionExitCode_{0};
+    double competenceSignal_{0.5};
+    std::size_t successfulActionCount_{0};
+    std::size_t failedActionCount_{0};
+    std::size_t completedGoalCount_{0};
+    std::size_t consecutiveActionFailures_{0};
+    // Rolling window of recent action outcomes (true=success) used by reasoning
+    // to detect repeated failure and switch to a safe fallback plan.
+    std::deque<bool> recentActionOutcomes_;
+
+    // Per-plan outcome feedback: plan label -> (successes, attempts).
+    struct PlanStats { std::size_t successes{0}; std::size_t attempts{0}; };
+    std::unordered_map<std::string, PlanStats> planStats_;
+
+    // Attention allocator used for goal prioritization. mutable so that const
+    // goal-selection accessors can update transient attention bookkeeping.
+    mutable AttentionAllocator goalAttention_;
+    UUID focusedGoalId_;
 };
 
 std::shared_ptr<AutonomousStarter> createAutolizaAgent();

--- a/include/elizaos/core.hpp
+++ b/include/elizaos/core.hpp
@@ -348,6 +348,24 @@ public:
     const std::vector<Actor>& getActors() const { return actors_; }
     const std::vector<StateGoal>& getGoals() const { return goals_; }
     const std::vector<std::shared_ptr<Memory>>& getRecentMessages() const { return recentMessages_; }
+
+    // Goal-status mutation API.
+    //
+    // These additive helpers let autonomy/cognitive loops close the feedback
+    // loop by progressing or completing goals in response to action outcomes,
+    // without breaking the existing read-only getGoals() contract. Each returns
+    // true when a matching goal was updated and refreshes the goal's updatedAt
+    // timestamp. Status comparison is case-insensitive on the description match
+    // but the supplied status string is stored verbatim.
+    // updateGoalStatus transitions an existing goal (matched by id) to a new
+    // status string and refreshes its updatedAt timestamp. Returns true when
+    // a goal was found and updated, false otherwise.
+    bool updateGoalStatus(const UUID& goalId, const std::string& status);
+    bool updateGoalStatusByDescription(const std::string& description,
+                                       const std::string& status);
+    // Returns the number of goals whose (case-insensitive) status equals the
+    // supplied value. Useful for measuring closed-loop progress.
+    std::size_t countGoalsWithStatus(const std::string& status) const;
     
 private:
     AgentConfig config_;


### PR DESCRIPTION
## Summary
Brings o9nn/elizaos-cpp to functional parity with hurdcog/elizaos.cpp for the autonomy and attention subsystems. **84/84 green** (was 80/80; +4 comprehensive suites, zero regressions).

## Changes
- **core `State`**: additive goal-status mutation API — `updateGoalStatus`, `updateGoalStatusByDescription`, `countGoalsWithStatus`.
- **autonomous_starter**: replaces the open-loop starter (~738 lines) with the advanced attention-weighted **closed-loop** goal lifecycle (single evidence-gated completion path, active-goal invariant, plan-bias learning, stagnation-with-purpose exemption). Links `elizaos-agentmemory` for the `AttentionAllocator` symbols (`attention.cpp` compiles into agentmemory in both forks).
- **attention**: ports the enhanced subsystem — `AttentionMessageBus`, `AttentionTransferProtocol`, `EnhancedAttentionAllocator`, `SaliencyDetector`, `AttentionCostBudget`, `AttentionPatternLearner`, `TemporalAttentionWindow`. Base `AttentionValue` gains ECAN `sti()/lti()` aliases (strict superset, backward compatible).
- **agentagenda**: lossless nanosecond timestamp serialization (same fix as hurdcog).
- **tests**: ports comprehensive E2E/unit suites via `add_real_test` — `real_closed_loop_autonomy_test` (12), `real_autonomy_reflection_test` (17), `real_autonomy_evolution_test` (12), `real_attention_bus_test` (11).

## Validation
`ctest`: **84/84** passing (100%).